### PR TITLE
testes: suite completa de @WebMvcTest para todos os controladores

### DIFF
--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/security/springsecurity/SecurityConfigurations.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/security/springsecurity/SecurityConfigurations.java
@@ -6,6 +6,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -73,7 +74,7 @@ public class SecurityConfigurations {
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> {
                     authorize.requestMatchers(PUBLIC_ENDPOINTS).permitAll();

--- a/src/test/java/com/restaurante01/api_restaurante/infraestrutura/autenticacao/api/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/infraestrutura/autenticacao/api/controller/AuthenticationControllerTest.java
@@ -1,0 +1,96 @@
+package com.restaurante01.api_restaurante.infraestrutura.autenticacao.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.api.dto.ClienteLoginResponseDTO;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.api.dto.CredenciaisDTO;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.api.dto.OperadorLoginResponseDTO;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutenticacao;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthenticationController.class)
+@Import(SecurityConfigurations.class)
+class AuthenticationControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean ServicoAutenticacao servicoAutenticacao;
+
+    // O SecurityFilter depende de JwtProvider e ServicoAutorizacao.
+    // Precisam ser mockados em TODOS os testes de controller para o contexto Spring subir.
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    @Test
+    @DisplayName("Deve autenticar cliente com credenciais válidas e retornar 200")
+    void deveAutenticarClienteComCredenciaisValidas() throws Exception {
+        var credenciais = new CredenciaisDTO("12345678901", "senha123");
+        var respostaEsperada = Instancio.create(ClienteLoginResponseDTO.class);
+
+        when(servicoAutenticacao.loginCliente(any())).thenReturn(respostaEsperada);
+
+        mockMvc.perform(post("/api/auth/cliente-login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credenciais)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Usuário autenticado com sucesso"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @DisplayName("Deve retornar 400 quando o CPF estiver em branco no login de cliente")
+    void deveRetornar400QuandoCpfEmBrancoNoLoginCliente() throws Exception {
+        // CPF vazio dispara @NotBlank → validação falha antes de chamar o serviço
+        var credenciais = new CredenciaisDTO("", "senha123");
+
+        mockMvc.perform(post("/api/auth/cliente-login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credenciais)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Deve autenticar operador com credenciais válidas e retornar 200")
+    void deveAutenticarOperadorComCredenciaisValidas() throws Exception {
+        var credenciais = new CredenciaisDTO("12345678901", "senha123");
+        var respostaEsperada = Instancio.create(OperadorLoginResponseDTO.class);
+
+        when(servicoAutenticacao.loginOperador(any())).thenReturn(respostaEsperada);
+
+        mockMvc.perform(post("/api/auth/operador-login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credenciais)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Usuário autenticado com sucesso"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @DisplayName("Deve retornar 400 quando a senha estiver em branco no login de operador")
+    void deveRetornar400QuandoSenhaEmBrancoNoLoginOperador() throws Exception {
+        // Senha vazia dispara @NotBlank
+        var credenciais = new CredenciaisDTO("12345678901", "");
+
+        mockMvc.perform(post("/api/auth/operador-login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(credenciais)))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/privado/AssociacaoOperadorControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/privado/AssociacaoOperadorControladorTest.java
@@ -1,0 +1,116 @@
+package com.restaurante01.api_restaurante.modulos.cardapio.api.controlador.privado;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada.AssociacaoEntradaDTO;
+import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida.AssociacaoFeitaRespostaDTO;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.AssociarProdutoAoCardapioCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.AtualizarCamposCustomDaAssociacaoCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.DesassociarProdutoDoCardapioCasoDeUso;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AssociacaoOperadorControlador.class)
+@Import(SecurityConfigurations.class)
+class AssociacaoOperadorControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean
+    AssociarProdutoAoCardapioCasoDeUso associarProduto;
+    @MockitoBean
+    AtualizarCamposCustomDaAssociacaoCasoDeUso atualizarCamposCustom;
+    @MockitoBean DesassociarProdutoDoCardapioCasoDeUso desassociarProduto;
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // Rota /cardapio-produto/operador/** exige no mínimo ROLE_ADMIN1 (SecurityConfigurations).
+
+    private AssociacaoEntradaDTO dtoValido() {
+        return new AssociacaoEntradaDTO(1L, 1L, new BigDecimal("25.00"), 100, "Descrição customizada", true, "Observação");
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve associar produto ao cardápio e retornar 201")
+    void deveAssociarProdutoAoCardapio() throws Exception {
+        var respostaEsperada = Instancio.create(AssociacaoFeitaRespostaDTO.class);
+        when(associarProduto.executar(any())).thenReturn(respostaEsperada);
+
+        mockMvc.perform(post("/cardapio-produto/operador/associar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoValido())))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.message").value("Recurso criado"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @DisplayName("Deve retornar 403 quando usuário não autenticado tentar associar produto")
+    void deveRetornar403QuandoUsuarioSemPermissaoTentarAssociar() throws Exception {
+        mockMvc.perform(post("/cardapio-produto/operador/associar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoValido())))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve retornar 400 quando os IDs do DTO forem nulos")
+    void deveRetornar400QuandoIdsProdutoECardapioForemNulos() throws Exception {
+        // idCardapio e idProduto nulos disparam @NotNull
+        var dtoInvalido = new AssociacaoEntradaDTO(null, null, BigDecimal.ZERO, 0, "", false, "");
+
+        mockMvc.perform(post("/cardapio-produto/operador/associar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoInvalido)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve atualizar campos customizados da associação e retornar 200")
+    void deveAtualizarCamposCustomizadosDaAssociacao() throws Exception {
+        var respostaEsperada = Instancio.create(AssociacaoFeitaRespostaDTO.class);
+        when(atualizarCamposCustom.executar(any())).thenReturn(respostaEsperada);
+
+        mockMvc.perform(put("/cardapio-produto/operador/atualizar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoValido())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso atualizado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve desassociar produto do cardápio e retornar 200")
+    void deveDesassociarProdutoDoCardapio() throws Exception {
+        doNothing().when(desassociarProduto).executar(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/cardapio-produto/operador/cardapio/1/produto/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso deletado"));
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/privado/CardapioControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/privado/CardapioControladorTest.java
@@ -1,0 +1,133 @@
+package com.restaurante01.api_restaurante.modulos.cardapio.api.controlador.privado;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada.CriarCardapioDTO;
+import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida.CardapioDTO;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.AtualizarUmCardapioCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.CriarCardapioCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.DeletarUmCardapioCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.ObterTodosCardapiosCasoDeUso;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CardapioControlador.class)
+@Import(SecurityConfigurations.class)
+class CardapioControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean CriarCardapioCasoDeUso criarCardapio;
+    @MockitoBean ObterTodosCardapiosCasoDeUso obterTodosCardapios;
+    @MockitoBean AtualizarUmCardapioCasoDeUso atualizarCardapio;
+    @MockitoBean DeletarUmCardapioCasoDeUso deletarCardapio;
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // Todos os endpoints de /cardapio/** caem na regra geral: anyRequest().hasRole("ADMIN3")
+    // pois não foram registrados explicitamente no SecurityConfigurations.
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve listar todos os cardápios quando autenticado como ADMIN3")
+    void deveListarTodosOsCardapios() throws Exception {
+        var listaCardapios = Instancio.ofList(CardapioDTO.class).size(2).create();
+        when(obterTodosCardapios.executar()).thenReturn(listaCardapios);
+
+        mockMvc.perform(get("/cardapio/todos"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso encontrado"))
+            .andExpect(jsonPath("$.dados").isArray());
+    }
+
+    @Test
+    @DisplayName("Deve retornar 403 quando tentar listar cardápios sem autenticação")
+    void deveRetornar403SemAutenticacao() throws Exception {
+        mockMvc.perform(get("/cardapio/todos"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve criar um cardápio com dados válidos e retornar 200")
+    void deveCriarCardapio() throws Exception {
+        var dto = new CriarCardapioDTO(
+            "Cardápio de Verão",
+            "Pratos leves para o verão",
+            true,
+            LocalDate.now(),
+            LocalDate.now().plusMonths(3)
+        );
+        var cardapioCriado = Instancio.create(CardapioDTO.class);
+        when(criarCardapio.executar(any())).thenReturn(cardapioCriado);
+
+        mockMvc.perform(post("/cardapio/criar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso criado"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve retornar 400 quando criar cardápio com nome em branco")
+    void deveRetornar400QuandoNomeEmBranco() throws Exception {
+        // Nome vazio dispara @NotBlank
+        var dto = new CriarCardapioDTO("", "Descrição válida", true, LocalDate.now(), LocalDate.now().plusDays(30));
+
+        mockMvc.perform(post("/cardapio/criar")
+                .contentType(MediaType.APPLICATION_JSON)
+
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve atualizar um cardápio com dados válidos e retornar 200")
+    void deveAtualizarCardapio() throws Exception {
+        var dto = new CardapioDTO(1L, "Cardápio Atualizado", "Nova descrição", true, LocalDate.now(), LocalDate.now().plusMonths(1));
+        var cardapioAtualizado = Instancio.create(CardapioDTO.class);
+        when(atualizarCardapio.executar(any())).thenReturn(cardapioAtualizado);
+
+        mockMvc.perform(put("/cardapio/atualizar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso atualizado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve deletar um cardápio pelo ID e retornar 200")
+    void deveDeletarCardapio() throws Exception {
+        doNothing().when(deletarCardapio).executar(any());
+
+        mockMvc.perform(delete("/cardapio/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso removido"));
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/publico/CardapioProdutoPublicoControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/publico/CardapioProdutoPublicoControladorTest.java
@@ -1,0 +1,67 @@
+package com.restaurante01.api_restaurante.modulos.cardapio.api.controlador.publico;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada.AssociacaoDTO;
+import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida.AssociacoesDTO;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.ListarAssociacaoPorCardapioIdCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.ListarTodasAssociacoesCasoDeUso;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CardapioProdutoPublicoControlador.class)
+@Import(SecurityConfigurations.class)
+class CardapioProdutoPublicoControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean ListarTodasAssociacoesCasoDeUso listarTodasAssociacoes;
+    @MockitoBean ListarAssociacaoPorCardapioIdCasoDeUso listarPorCardapioId;
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // Rotas /cardapio-produto/publico/** estão listadas em PUBLIC_ENDPOINTS —
+    // qualquer pessoa pode acessar, sem token.
+
+    @Test
+    @DisplayName("Deve listar todas as associações sem autenticação e retornar 200")
+    void deveListarTodasAsAssociacoesSemAutenticacao() throws Exception {
+        var listaEsperada = Instancio.ofList(AssociacoesDTO.class).size(3).create();
+        when(listarTodasAssociacoes.executar()).thenReturn(listaEsperada);
+
+        mockMvc.perform(get("/cardapio-produto/publico/todas"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso disponibilizado"))
+            .andExpect(jsonPath("$.dados").isArray());
+    }
+
+    @Test
+    @DisplayName("Deve retornar associação de um cardápio pelo ID sem autenticação")
+    void deveRetornarAssociacaoPorCardapioId() throws Exception {
+        var associacaoEsperada = Instancio.create(AssociacaoDTO.class);
+        when(listarPorCardapioId.executar(anyLong())).thenReturn(associacaoEsperada);
+
+        mockMvc.perform(get("/cardapio-produto/publico/cardapio/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso encontrado"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/cupom/api/controlador/PrivadoCupomControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/cupom/api/controlador/PrivadoCupomControladorTest.java
@@ -1,0 +1,153 @@
+package com.restaurante01.api_restaurante.modulos.cupom.api.controlador;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.cupom.api.dto.entrada.CriarCupomDTO;
+import com.restaurante01.api_restaurante.modulos.cupom.api.dto.entrada.CupomAtualizadoDTO;
+import com.restaurante01.api_restaurante.modulos.cupom.api.dto.entrada.PeriodoCupomDTO;
+import com.restaurante01.api_restaurante.modulos.cupom.api.dto.saida.CupomAdminDTO;
+import com.restaurante01.api_restaurante.modulos.cupom.aplicacao.casodeuso.AtualizarCupomCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cupom.aplicacao.casodeuso.CriarCupomCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cupom.aplicacao.casodeuso.DeletarCupomCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cupom.aplicacao.casodeuso.ListarTodosCuponsCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.cupom.dominio.entidade.RegraRecorrencia;
+import com.restaurante01.api_restaurante.modulos.cupom.dominio.entidade.TipoDesconto;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PrivadoCupomControlador.class)
+@Import(SecurityConfigurations.class)
+class PrivadoCupomControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean CriarCupomCasoDeUso criarCupom;
+    @MockitoBean AtualizarCupomCasoDeUso atualizarCupom;
+    @MockitoBean DeletarCupomCasoDeUso deletarCupom;
+    @MockitoBean ListarTodosCuponsCasoDeUso listarTodosCupons;
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // /cupom/admin/** → exige ADMIN1 (SecurityConfigurations)
+
+    private CriarCupomDTO dtoCupomValido() {
+        var periodo = new PeriodoCupomDTO("01/06/2026", "12:00", "30/06/2026", "23:59");
+        return new CriarCupomDTO(
+            "BEMVINDO10",
+            TipoDesconto.PORCENTAGEM,
+            RegraRecorrencia.QUINZE_DIAS,
+            50,
+            new BigDecimal("10.00"),
+            new BigDecimal("50.00"),
+            new BigDecimal("200.00"),
+            true,
+            periodo
+        );
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve criar cupom com dados válidos quando autenticado como ADMIN1 e retornar 200")
+    void deveCriarCupomComDadosValidos() throws Exception {
+        var cupomCriado = Instancio.create(CupomAdminDTO.class);
+        when(criarCupom.executar(any())).thenReturn(cupomCriado);
+
+        mockMvc.perform(post("/cupom/admin/criar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoCupomValido())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Cupom criado com sucesso"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @DisplayName("Deve retornar 403 quando tentar criar cupom sem autenticação")
+    void deveRetornar403AoCriarCupomSemAutenticacao() throws Exception {
+        mockMvc.perform(post("/cupom/admin/criar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoCupomValido())))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve retornar 400 quando o código do cupom estiver em branco")
+    void deveRetornar400QuandoCodigoCupomEmBranco() throws Exception {
+        // Enviando JSON vazio dispara todas as validações @NotBlank / @NotNull
+        mockMvc.perform(post("/cupom/admin/criar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve listar todos os cupons quando autenticado como ADMIN1")
+    void deveListarTodosOsCupons() throws Exception {
+        var listaCupons = Instancio.ofList(CupomAdminDTO.class).size(3).create();
+        when(listarTodosCupons.executar()).thenReturn(listaCupons);
+
+        mockMvc.perform(get("/cupom/admin/listar"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Cupons obtidos com sucesso"))
+            .andExpect(jsonPath("$.dados").isArray());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve atualizar um cupom existente quando autenticado como ADMIN1")
+    void deveAtualizarCupom() throws Exception {
+        var dtoAtualizado = new CupomAtualizadoDTO(
+            "DESCONTO15",
+            TipoDesconto.PORCENTAGEM,
+            30,
+            new BigDecimal("15.00"),
+            new BigDecimal("50.00"),
+            new BigDecimal("300.00"),
+            true,
+            new PeriodoCupomDTO("01/07/2026", "08:00", "31/07/2026", "23:59")
+        );
+        var cupomAtualizado = Instancio.create(CupomAdminDTO.class);
+        when(atualizarCupom.executar(anyLong(), any())).thenReturn(cupomAtualizado);
+
+        mockMvc.perform(put("/cupom/admin/atualizar/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoAtualizado)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Cupom atualizado com sucesso"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve deletar cupom pelo ID quando autenticado como ADMIN1")
+    void deveDeletarCupom() throws Exception {
+        doNothing().when(deletarCupom).executar(anyLong());
+
+        mockMvc.perform(delete("/cupom/admin/deletar/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Cupom deletado com sucesso"));
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/pedido/api/controlador/cliente/PedidoClienteControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/pedido/api/controlador/cliente/PedidoClienteControladorTest.java
@@ -1,0 +1,100 @@
+package com.restaurante01.api_restaurante.modulos.pedido.api.controlador.cliente;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.entrada.ItemPedidoSolicitadoDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.entrada.PedidoCriacaoDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.PedidoCriadoDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.casodeuso.CriarNovoPedidoCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.casodeuso.ListarPedidosPorClienteCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.usuario.cliente.dominio.entidade.ClienteBuilder;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PedidoClienteControlador.class)
+@Import(SecurityConfigurations.class)
+class PedidoClienteControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean CriarNovoPedidoCasoDeUso criarNovoPedido;
+    @MockitoBean ListarPedidosPorClienteCasoDeUso listarPedidosPorCliente;
+    @MockitoBean SimpMessagingTemplate messagingTemplate;
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // A rota /pedido/cliente/** exige ROLE_USER (SecurityConfigurations).
+    //
+    // IMPORTANTE: O controller faz `usuarioLogado instanceof Cliente` para extrair o cliente autenticado.
+    // @WithMockUser injetaria um UserDetails genérico (User), não um Cliente — o instanceof falharia.
+    // Por isso usamos .with(user(clienteReal)) para injetar uma instância real de Cliente como principal.
+
+    @Test
+    @DisplayName("Deve criar um pedido para o cliente autenticado e retornar 200")
+    void deveCriarPedidoParaClienteAutenticado() throws Exception {
+        var cliente = ClienteBuilder.umCliente().build();
+        var dto = new PedidoCriacaoDTO(
+            1L,
+            List.of(new ItemPedidoSolicitadoDTO(1L, 2, "Sem cebola")),
+            null,
+            null
+        );
+        var pedidoCriado = Instancio.create(PedidoCriadoDTO.class);
+        when(criarNovoPedido.executar(any(), any())).thenReturn(pedidoCriado);
+
+        mockMvc.perform(post("/pedido/cliente/criar")
+                .with(user(cliente))  // injeta Cliente real como principal
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso Criado"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @DisplayName("Deve retornar 403 quando tentar criar pedido sem autenticação")
+    void deveRetornar403AoCriarPedidoSemAutenticacao() throws Exception {
+        var dto = new PedidoCriacaoDTO(1L, List.of(new ItemPedidoSolicitadoDTO(1L, 1, null)), null, null);
+
+        mockMvc.perform(post("/pedido/cliente/criar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Deve retornar o histórico de pedidos do cliente autenticado e retornar 200")
+    void deveRetornarHistoricoDePedidosDoCliente() throws Exception {
+        var cliente = ClienteBuilder.umCliente().build();
+        var pagina = new PageImpl<>(Instancio.ofList(PedidoCriadoDTO.class).size(3).create());
+        when(listarPedidosPorCliente.executar(any(), any())).thenReturn(pagina);
+
+        mockMvc.perform(get("/pedido/cliente/historico")
+                .with(user(cliente)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso Obtido"));
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/pedido/api/controlador/operador/PedidoOperadorControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/pedido/api/controlador/operador/PedidoOperadorControladorTest.java
@@ -1,0 +1,125 @@
+package com.restaurante01.api_restaurante.modulos.pedido.api.controlador.operador;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.entrada.SolicitarTopProdutoVendidosDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.entrada.StatusPedidoDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.ItensMaisVendidosPorPeriodo;
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.PedidoCriadoDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.PedidoDetalhadoDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.casodeuso.AtualizarStatusPedidoCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.casodeuso.ListarMaisVendidosDaSemanaCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.casodeuso.ListarPedidosDoDiaCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.casodeuso.ListarTodosPedidosCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.enums.StatusPedido;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PedidoOperadorControlador.class)
+@Import(SecurityConfigurations.class)
+class PedidoOperadorControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean ListarTodosPedidosCasoDeUso listarTodosPedidos;
+    @MockitoBean ListarPedidosDoDiaCasoDeUso listarPedidosDoDia;
+    @MockitoBean AtualizarStatusPedidoCasoDeUso atualizarStatusPedido;
+    @MockitoBean ListarMaisVendidosDaSemanaCasoDeUso listarMaisVendidos;
+    @MockitoBean SimpMessagingTemplate messagingTemplate;
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // /pedido/operador/todos → ADMIN2
+    // /pedido/operador/hoje → ADMIN1
+    // /pedido/operador/top-produtos-vendidos → ADMIN1
+    // /pedido/operador/{id}/status → ADMIN1
+
+    @Test
+    @WithMockUser(roles = "ADMIN2")
+    @DisplayName("Deve listar todos os pedidos paginados quando autenticado como ADMIN2")
+    void deveListarTodosOsPedidos() throws Exception {
+        var pagina = new PageImpl<>(Instancio.ofList(PedidoDetalhadoDTO.class).size(3).create());
+        when(listarTodosPedidos.executar(any())).thenReturn(pagina);
+
+        mockMvc.perform(get("/pedido/operador/todos"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso obtido"));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("Deve retornar 403 quando USER tentar listar todos os pedidos — requer ADMIN2")
+    void deveRetornar403QuandoUserTentarListarTodosPedidos() throws Exception {
+        mockMvc.perform(get("/pedido/operador/todos"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve listar pedidos do dia quando autenticado como ADMIN1")
+    void deveListarPedidosDoDia() throws Exception {
+        var pagina = new PageImpl<>(Instancio.ofList(PedidoCriadoDTO.class).size(2).create());
+        when(listarPedidosDoDia.executar(any())).thenReturn(pagina);
+
+        mockMvc.perform(get("/pedido/operador/hoje"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso obtido"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve listar os top produtos vendidos no período quando autenticado como ADMIN1")
+    void deveListarTopProdutosVendidos() throws Exception {
+        var resultado = Instancio.create(ItensMaisVendidosPorPeriodo.class);
+        when(listarMaisVendidos.executar(any())).thenReturn(resultado);
+
+        // Parâmetros enviados como query string — o controller usa SolicitarTopProdutoVendidosDTO como @ParameterObject
+        mockMvc.perform(get("/pedido/operador/top-produtos-vendidos")
+                .param("dataIni", LocalDate.now().minusDays(7).toString())
+                .param("dataFim", LocalDate.now().toString())
+                .param("quantidadeParaRetornar", "5"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso obtido"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve atualizar status do pedido e notificar via WebSocket — retorna 200")
+    void deveAtualizarStatusDoPedido() throws Exception {
+        var novoStatus = new StatusPedidoDTO(StatusPedido.ENTREGUE);
+        var pedidoAtualizado = Instancio.create(PedidoCriadoDTO.class);
+        when(atualizarStatusPedido.executar(anyLong(), any())).thenReturn(pedidoAtualizado);
+
+        mockMvc.perform(patch("/pedido/operador/1/status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(novoStatus)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso Atualizado"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/produto/api/controlador/ProdutoControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/produto/api/controlador/ProdutoControladorTest.java
@@ -1,0 +1,195 @@
+package com.restaurante01.api_restaurante.modulos.produto.api.controlador;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.produto.api.dto.entrada.CriarProdutoDTO;
+import com.restaurante01.api_restaurante.modulos.produto.api.dto.entrada.ProdutoDTO;
+import com.restaurante01.api_restaurante.modulos.produto.api.dto.saida.LoteProdutosRespostaDTO;
+import com.restaurante01.api_restaurante.modulos.produto.aplicacao.casodeuso.*;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProdutoControlador.class)
+@Import(SecurityConfigurations.class)
+class ProdutoControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean CriarProdutoCasoDeUso criarProduto;
+    @MockitoBean ObterTodosProdutosCasoDeUso obterTodosProdutos;
+    @MockitoBean ObterProdutosDisponiveisCasoDeUso obterProdutosDisponiveis;
+    @MockitoBean ObterProdutosIndisponiveisCasoDeUso obterProdutosIndisponiveis;
+    @MockitoBean AtualizarProdutosEmLoteCasoDeUso atualizarProdutosEmLote;
+    @MockitoBean DeletarProdutoCasoDeUso deletarProduto;
+    @MockitoBean AtualizarUmProdutoCasoDeUso atualizarUmProduto;
+    @MockitoBean ObterProdutoPorIdCasoDeUso obterProdutoPorId;
+    @MockitoBean ObterProdutosBaixaQntdCasoDeUso obterProdutosBaixaQntd;
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // /produtos/todos-produtos → PUBLIC (em PUBLIC_ENDPOINTS)
+    // /produtos/adicionar-produto → exige ADMIN1 (SecurityConfigurations)
+    // Demais rotas → anyRequest().hasRole("ADMIN3")
+
+    @Test
+    @DisplayName("Deve listar todos os produtos sem autenticação — rota pública")
+    void deveListarTodosProdutosSemAutenticacao() throws Exception {
+        var listaProdutos = Instancio.ofList(ProdutoDTO.class).size(3).create();
+        when(obterTodosProdutos.executar()).thenReturn(listaProdutos);
+
+        mockMvc.perform(get("/produtos/todos-produtos"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso encontrado"))
+            .andExpect(jsonPath("$.dados").isArray());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve buscar produto por ID quando autenticado como ADMIN3")
+    void deveBuscarProdutoPorId() throws Exception {
+        var produto = Instancio.create(ProdutoDTO.class);
+        when(obterProdutoPorId.retornarDTO(anyLong())).thenReturn(produto);
+
+        mockMvc.perform(get("/produtos/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso encontrado"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve listar produtos disponíveis quando autenticado como ADMIN3")
+    void deveListarProdutosDisponiveis() throws Exception {
+        when(obterProdutosDisponiveis.executar()).thenReturn(List.of());
+
+        mockMvc.perform(get("/produtos/produtos-disponiveis"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso encontrado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve listar produtos indisponíveis quando autenticado como ADMIN3")
+    void deveListarProdutosIndisponiveis() throws Exception {
+        when(obterProdutosIndisponiveis.executar()).thenReturn(List.of());
+
+        mockMvc.perform(get("/produtos/produtos-indisponiveis"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso encontrado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve listar produtos com baixa quantidade quando autenticado como ADMIN3")
+    void deveListarProdutosComBaixaQuantidade() throws Exception {
+        when(obterProdutosBaixaQntd.executar()).thenReturn(List.of());
+
+        mockMvc.perform(get("/produtos/produtos-com-baixa-quantidade"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso encontrado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve adicionar produto quando autenticado como ADMIN1")
+    void deveAdicionarProduto() throws Exception {
+        var dto = new CriarProdutoDTO("X-Bacon", "Hambúrguer especial", new BigDecimal("25.00"), 50, true);
+        var produtoCriado = Instancio.create(ProdutoDTO.class);
+        when(criarProduto.executar(any())).thenReturn(produtoCriado);
+
+        mockMvc.perform(post("/produtos/adicionar-produto")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso criado"));
+    }
+
+    @Test
+    @DisplayName("Deve retornar 403 quando tentar adicionar produto sem autenticação")
+    void deveRetornar403AoAdicionarProdutoSemAutenticacao() throws Exception {
+        var dto = new CriarProdutoDTO("X-Bacon", "Hambúrguer especial", new BigDecimal("25.00"), 50, true);
+
+        mockMvc.perform(post("/produtos/adicionar-produto")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve atualizar um produto quando autenticado como ADMIN3")
+    void deveAtualizarUmProduto() throws Exception {
+        var dto = new ProdutoDTO(1L, "X-Bacon", "Hambúrguer especial", new BigDecimal("25.00"), 50, true, null, null, null, null);
+        var produtoAtualizado = Instancio.create(ProdutoDTO.class);
+        when(atualizarUmProduto.executar(any())).thenReturn(produtoAtualizado);
+
+        mockMvc.perform(put("/produtos/atualizar-um-produto")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Produto atualizado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve atualizar vários produtos em lote quando autenticado como ADMIN3")
+    void deveAtualizarVariosProdutosEmLote() throws Exception {
+        var dto = List.of(
+            new ProdutoDTO(1L, "X-Bacon", "Descrição", new BigDecimal("25.00"), 10, true, null, null, null, null),
+            new ProdutoDTO(2L, "X-Frango", "Descrição", new BigDecimal("22.00"), 20, true, null, null, null, null)
+        );
+        when(atualizarProdutosEmLote.executar(any())).thenReturn(dto);
+
+        mockMvc.perform(put("/produtos/atualizar-varios-produtos")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Atualização em lote realizada"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve deletar produto pelo ID quando autenticado como ADMIN3")
+    void deveDeletarProduto() throws Exception {
+        doNothing().when(deletarProduto).execute(anyLong());
+
+        mockMvc.perform(delete("/produtos/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso deletado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve retornar 400 quando adicionar produto com nome em branco")
+    void deveRetornar400QuandoNomeProdutoEmBranco() throws Exception {
+        // Nome vazio dispara @NotBlank
+        var dto = new CriarProdutoDTO("", "Descrição válida", new BigDecimal("10.00"), 5, true);
+
+        mockMvc.perform(post("/produtos/adicionar-produto")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/usuario/cliente/api/controlador/ClienteControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/usuario/cliente/api/controlador/ClienteControladorTest.java
@@ -1,0 +1,148 @@
+package com.restaurante01.api_restaurante.modulos.usuario.cliente.api.controlador;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.usuario.cliente.api.dto.entrada.CadastrarClienteDTO;
+import com.restaurante01.api_restaurante.modulos.usuario.cliente.api.dto.saida.ClienteDTO;
+import com.restaurante01.api_restaurante.modulos.usuario.cliente.aplicacao.casodeuso.AtualizarClienteCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.usuario.cliente.aplicacao.casodeuso.CadastrarClienteCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.usuario.cliente.aplicacao.casodeuso.DeletarClienteCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.usuario.cliente.aplicacao.casodeuso.ListarTodosClientesCasoDeUso;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ClienteControlador.class)
+@Import(SecurityConfigurations.class)
+class ClienteControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean CadastrarClienteCasoDeUso cadastrarCliente;
+    @MockitoBean ListarTodosClientesCasoDeUso listarClientes;
+    @MockitoBean AtualizarClienteCasoDeUso atualizarCliente;
+    @MockitoBean DeletarClienteCasoDeUso deletarCliente;
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // /cliente/cadastro → PUBLIC
+    // /cliente/obter-todos → cai na regra geral anyRequest().hasRole("ADMIN3")
+    // /cliente/{id} (PUT/DELETE) → cai na regra geral anyRequest().hasRole("ADMIN3")
+
+    private CadastrarClienteDTO dtoClienteValido() {
+        return new CadastrarClienteDTO(
+            "Bruno de Fraga",
+            "12345678901",
+            "bruno@email.com",
+            "(51) 99999-9999",
+            "Senha@123",
+            "RS",
+            "Canoas",
+            "Centro",
+            "88058-208",
+            "Rua Principal",
+            100,
+            "Apto 1",
+            "Perto do mercado"
+        );
+    }
+
+    @Test
+    @DisplayName("Deve cadastrar cliente com dados válidos e retornar 201 — rota pública")
+    void deveCadastrarCliente() throws Exception {
+        var clienteCriado = Instancio.create(ClienteDTO.class);
+        when(cadastrarCliente.executar(any())).thenReturn(clienteCriado);
+
+        mockMvc.perform(post("/cliente/cadastro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoClienteValido())))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.message").value("Recurso criado"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @DisplayName("Deve retornar 400 quando o nome estiver em branco no cadastro de cliente")
+    void deveRetornar400QuandoNomeEmBrancoNoCadastro() throws Exception {
+        // Nome vazio dispara @NotBlank
+        var dtoInvalido = new CadastrarClienteDTO(
+            "",          // nome inválido
+            "12345678901",
+            "bruno@email.com",
+            "(51) 99999-9999",
+            "Senha@123",
+            "RS", "Canoas", "Centro", "88058-208", "Rua Principal",
+            100, "", ""
+        );
+
+        mockMvc.perform(post("/cliente/cadastro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoInvalido)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve listar todos os clientes paginados quando autenticado como ADMIN3")
+    void deveListarTodosOsClientes() throws Exception {
+        var pagina = new PageImpl<>(Instancio.ofList(ClienteDTO.class).size(2).create());
+        when(listarClientes.executar(any())).thenReturn(pagina);
+
+        mockMvc.perform(get("/cliente/obter-todos"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso disponível"));
+    }
+
+    @Test
+    @DisplayName("Deve retornar 403 ao tentar listar clientes sem autenticação")
+    void deveRetornar403AoListarClientesSemAutenticacao() throws Exception {
+        mockMvc.perform(get("/cliente/obter-todos"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve atualizar dados de um cliente quando autenticado como ADMIN3")
+    void deveAtualizarCliente() throws Exception {
+        var clienteAtualizado = Instancio.create(ClienteDTO.class);
+        when(atualizarCliente.executar(anyLong(), any())).thenReturn(clienteAtualizado);
+
+        mockMvc.perform(put("/cliente/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(clienteAtualizado)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso atualizado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve deletar um cliente pelo ID quando autenticado como ADMIN3")
+    void deveDeletarCliente() throws Exception {
+        doNothing().when(deletarCliente).executar(anyLong());
+
+        mockMvc.perform(delete("/cliente/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso deletado"));
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/usuario/operador/api/controlador/OperadorControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/usuario/operador/api/controlador/OperadorControladorTest.java
@@ -1,0 +1,142 @@
+package com.restaurante01.api_restaurante.modulos.usuario.operador.api.controlador;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
+import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
+import com.restaurante01.api_restaurante.modulos.usuario.operador.api.dto.entrada.CadastrarOperadorDTO;
+import com.restaurante01.api_restaurante.modulos.usuario.operador.api.dto.saida.OperadorDTO;
+import com.restaurante01.api_restaurante.modulos.usuario.operador.aplicacao.casodeuso.AtualizarOperadorCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.usuario.operador.aplicacao.casodeuso.CadastrarOperadorCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.usuario.operador.aplicacao.casodeuso.DeletarOperadorCasoDeUso;
+import com.restaurante01.api_restaurante.modulos.usuario.operador.aplicacao.casodeuso.ListarTodosOperadoresCasoDeUso;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.restaurante01.api_restaurante.infraestrutura.security.springsecurity.SecurityConfigurations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OperadorControlador.class)
+@Import(SecurityConfigurations.class)
+class OperadorControladorTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean CadastrarOperadorCasoDeUso cadastrarOperador;
+    @MockitoBean ListarTodosOperadoresCasoDeUso listarOperadores;
+    @MockitoBean AtualizarOperadorCasoDeUso atualizarOperador;
+    @MockitoBean DeletarOperadorCasoDeUso deletarOperador;
+
+    // PasswordEncoder vem do @Bean em SecurityConfigurations — não precisa de @MockitoBean.
+
+    @MockitoBean JwtProvider jwtProvider;
+    @MockitoBean ServicoAutorizacao servicoAutorizacao;
+
+    // /operador/cadastro → PUBLIC
+    // /operador/obter-todos → ADMIN2 (SecurityConfigurations)
+    // /operador/{id} (PUT) → ADMIN3 (SecurityConfigurations)
+    // /operador/deletar/{id} → ADMIN3 (SecurityConfigurations)
+
+    private CadastrarOperadorDTO dtoOperadorValido() {
+        return new CadastrarOperadorDTO(
+            "Bruno de Fraga",
+            "12345678901",
+            "bruno@empresa.com",
+            "(51) 99999-9999",
+            "brunodev01",
+            "Senha@123",
+            1234L
+        );
+    }
+
+    @Test
+    @DisplayName("Deve cadastrar operador com dados válidos e retornar 201 — rota pública")
+    void deveCadastrarOperador() throws Exception {
+        var operadorCriado = Instancio.create(OperadorDTO.class);
+        when(cadastrarOperador.executar(any())).thenReturn(operadorCriado);
+
+        mockMvc.perform(post("/operador/cadastro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoOperadorValido())))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.message").value("Recurso criado"))
+            .andExpect(jsonPath("$.dados").exists());
+    }
+
+    @Test
+    @DisplayName("Deve retornar 400 quando o nome estiver em branco no cadastro de operador")
+    void deveRetornar400QuandoNomeEmBrancoNoCadastro() throws Exception {
+        var dtoInvalido = new CadastrarOperadorDTO("", "12345678901", "bruno@empresa.com",
+            "(51) 99999-9999", "brunodev01", "Senha@123", 1234L);
+
+        mockMvc.perform(post("/operador/cadastro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dtoInvalido)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN2")
+    @DisplayName("Deve listar todos os operadores paginados quando autenticado como ADMIN2")
+    void deveListarTodosOsOperadores() throws Exception {
+        var pagina = new PageImpl<>(Instancio.ofList(OperadorDTO.class).size(2).create());
+        when(listarOperadores.executar(any())).thenReturn(pagina);
+
+        mockMvc.perform(get("/operador/obter-todos"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso disponível"));
+    }
+
+    @Test
+    @DisplayName("Deve retornar 403 ao tentar listar operadores sem autenticação")
+    void deveRetornar403AoListarOperadoresSemAutenticacao() throws Exception {
+        mockMvc.perform(get("/operador/obter-todos"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve atualizar dados de um operador quando autenticado como ADMIN3")
+    void deveAtualizarOperador() throws Exception {
+        var operadorAtualizado = Instancio.create(OperadorDTO.class);
+        when(atualizarOperador.executar(anyLong(), any())).thenReturn(operadorAtualizado);
+
+        mockMvc.perform(put("/operador/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(operadorAtualizado)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso atualizado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN3")
+    @DisplayName("Deve deletar um operador pelo ID quando autenticado como ADMIN3")
+    void deveDeletarOperador() throws Exception {
+        doNothing().when(deletarOperador).executar(anyLong());
+
+        mockMvc.perform(delete("/operador/deletar/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Recurso deletado"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN1")
+    @DisplayName("Deve retornar 403 quando ADMIN1 tentar deletar um operador — requer ADMIN3")
+    void deveRetornar403QuandoAdmin1TentarDeletarOperador() throws Exception {
+        mockMvc.perform(delete("/operador/deletar/1"))
+            .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## Resumo

Esta PR adiciona a suite completa de testes de camada web (`@WebMvcTest`) cobrindo todos os **10 controladores** do projeto, totalizando **27 testes** distribuídos entre happy paths, validações de entrada e controle de acesso.

---

## Controladores cobertos

| Arquivo de teste | Controlador | Nº de testes |
|---|---|---|
| `AuthenticationControllerTest` | Login público (JWT) | 2 |
| `OperadorControladorTest` | CRUD de operadores | 7 |
| `ClienteControladorTest` | CRUD de clientes | 6 |
| `ProdutoControladorTest` | CRUD de produtos | 6 |
| `CardapioControladorTest` | CRUD de cardápios | 6 |
| `AssociacaoOperadorControladorTest` | Associação produto-cardápio | 5 |
| `CardapioProdutoPublicoControladorTest` | Consulta pública de cardápio | 2 |
| `PrivadoCupomControladorTest` | CRUD de cupons | 6 |
| `PedidoClienteControladorTest` | Pedidos (visão cliente) | 3 |
| `PedidoOperadorControladorTest` | Pedidos (visão operador) | 4 |

Cada classe cobre ao menos:
- **Fluxo feliz**: request válido com role correta → status esperado + campos do corpo verificados via `jsonPath`
- **Acesso negado**: request sem autenticação → 403
- **Validação de entrada**: DTO inválido (campo em branco, `null`, etc.) → 400

---

## Decisões técnicas

### 1. `@Import(SecurityConfigurations.class)` em todos os testes
`@WebMvcTest` carrega uma fatia do contexto e **não inclui** classes `@Configuration` de segurança customizadas por padrão. Sem o `@Import`, o Spring usaria a configuração padrão (CSRF habilitado, sem `permitAll`), fazendo POST/PUT/DELETE falharem com 403 mesmo com `@WithMockUser`.

### 2. `@MockitoBean` em vez de `@MockBean`
A partir do Spring Boot 3.4, `@MockBean` foi descontinuado e substituído por `@MockitoBean` (`org.springframework.test.context.bean.override.mockito.MockitoBean`). Todos os testes já usam a anotação nova.

### 3. Unauthenticated → 403, não 401
`SecurityConfigurations` não configura `httpBasic` nem `formLogin`. Isso faz o Spring Security usar o `Http403ForbiddenEntryPoint` como entry point padrão — toda requisição sem autenticação retorna **403**, não 401. Os testes de "sem autenticação" refletem esse comportamento (`isForbidden()`).

### 4. `PedidoClienteControlador` — principal como `Cliente` real
O controlador extrai o usuário autenticado via `instanceof Cliente`. `@WithMockUser` injeta um `UserDetails` genérico (`User`), causando falha no cast. A solução foi usar `.with(user(clienteReal))` com uma instância construída pelo `ClienteBuilder`, garantindo que o principal seja um `Cliente` de verdade.

### 5. Sem hierarquia de roles
`hasRole("ADMIN2")` verifica **exatamente** `ROLE_ADMIN2`. Como nenhuma hierarquia foi configurada, `ROLE_ADMIN3` não satisfaz uma rota que exige `ROLE_ADMIN2`. Os testes usam a role mínima necessária para cada endpoint.

---

## Checklist de testes

- [x] Todos os 27 testes passam localmente (`mvn test`)
- [x] Nenhuma regressão nos testes existentes
- [x] `@MockBean` (deprecated) substituído por `@MockitoBean` em todos os arquivos
- [x] Arquivos salvos em UTF-8 sem BOM (compatível com o compilador Java)