### PR TITLE
fix: corrige bug no módulo associativo e converte DTOs para records

### DIFF
--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/publico/AssociacaoPublicoControlador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/publico/AssociacaoPublicoControlador.java
@@ -1,7 +1,6 @@
 package com.restaurante01.api_restaurante.modulos.cardapio.api.controlador.publico;
 
 import com.restaurante01.api_restaurante.compartilhado.retorno_padrao_api.ApiResponse;
-import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada.AssociacaoDTO;
 import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida.AssociacoesDTO;
 import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.ListarAssociacaoPorCardapioIdCasoDeUso;
 import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.ListarTodasAssociacoesCasoDeUso;
@@ -19,12 +18,12 @@ import java.util.List;
 @CrossOrigin(origins = "*")
 @Validated
 @Tag(name = "-> Cardápio & Produto - Vitrine Pública", description = "Endpoints abertos para visitantes visualizarem os cardápios")
-public class CardapioProdutoPublicoControlador {
+public class AssociacaoPublicoControlador {
 
     private final ListarTodasAssociacoesCasoDeUso listarTodasAssociacoes;
     private final ListarAssociacaoPorCardapioIdCasoDeUso listarPorCardapioId;
 
-    public CardapioProdutoPublicoControlador(
+    public AssociacaoPublicoControlador(
             ListarTodasAssociacoesCasoDeUso listarTodasAssociacoes,
             ListarAssociacaoPorCardapioIdCasoDeUso listarPorCardapioId) {
         this.listarTodasAssociacoes = listarTodasAssociacoes;
@@ -39,7 +38,7 @@ public class CardapioProdutoPublicoControlador {
 
     @Operation(summary = "Obter produtos de um cardápio", description = "Retorna a associação de produtos de um cardápio específico. Rota pública.")
     @GetMapping("/cardapio/{idCardapio}")
-    public ResponseEntity<ApiResponse<AssociacaoDTO>> obterAssociacaoPorCardapioId(@PathVariable @Min(1) long idCardapio){
+    public ResponseEntity<ApiResponse<AssociacoesDTO>> obterAssociacaoPorCardapioId(@PathVariable @Min(1) long idCardapio){
         return ResponseEntity.ok(ApiResponse.success("Recurso encontrado", listarPorCardapioId.executar(idCardapio)));
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/entrada/AssociacaoDTO.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/entrada/AssociacaoDTO.java
@@ -2,37 +2,16 @@ package com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada;
 
 import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida.CardapioDTO;
 import com.restaurante01.api_restaurante.modulos.produto.api.dto.entrada.ProdutoDTO;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.math.BigDecimal;
 
-@Setter
-@Getter
-public class AssociacaoDTO {
-    private Long id;
-    private CardapioDTO cardapio;
-    private ProdutoDTO produto;
-    private BigDecimal precoCustomizado;
-    private Integer quantidadeCustomizada;
-    private String descricaoCustomizada;
-    private Boolean disponibilidadeCustomizada;
-    private String observacao;
-
-    public AssociacaoDTO() {
-    }
-
-    public AssociacaoDTO(Long id, CardapioDTO cardapio, ProdutoDTO produto, BigDecimal precoCustomizado,
-                         Integer quantidadeCustomizada, String descricaoCustomizada,
-                         Boolean disponibilidadeCustomizada, String observacao) {
-        this.id = id;
-        this.cardapio = cardapio;
-        this.produto = produto;
-        this.precoCustomizado = precoCustomizado;
-        this.quantidadeCustomizada = quantidadeCustomizada;
-        this.descricaoCustomizada = descricaoCustomizada;
-        this.disponibilidadeCustomizada = disponibilidadeCustomizada;
-        this.observacao = observacao;
-    }
-
-}
+public record AssociacaoDTO(
+        Long id,
+        CardapioDTO cardapio,
+        ProdutoDTO produto,
+        BigDecimal precoCustomizado,
+        Integer quantidadeCustomizada,
+        String descricaoCustomizada,
+        Boolean disponibilidadeCustomizada,
+        String observacao
+) {}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/entrada/AssociacaoEntradaDTO.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/entrada/AssociacaoEntradaDTO.java
@@ -2,37 +2,15 @@ package com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.math.BigDecimal;
 
-@Setter
-@Getter
-public class AssociacaoEntradaDTO {
-    @NotNull(message = "ID do cardapio deve ser enviada")
-    @Min(1)
-    private Long idCardapio;
-    @Min(1)
-    @NotNull (message = "ID do produto deve ser enviada")
-    private Long idProduto;
-    @Min(0)
-    private BigDecimal precoCustomizado;
-    @Min(0)
-    private Integer quantidadeCustomizada;
-    private String descricaoCustomizada;
-    private Boolean disponibilidadeCustomizada;
-    private String observacao;
-    
-
-    public AssociacaoEntradaDTO(Long idCardapio, Long idProduto, BigDecimal precoCustomizado, Integer quantidadeCustomizada, String descricaoCustomizada, Boolean disponibilidadeCustomizada, String observacao) {
-        this.idCardapio = idCardapio;
-        this.idProduto = idProduto;
-        this.precoCustomizado = precoCustomizado;
-        this.quantidadeCustomizada = quantidadeCustomizada;
-        this.descricaoCustomizada = descricaoCustomizada;
-        this.disponibilidadeCustomizada = disponibilidadeCustomizada;
-        this.observacao = observacao;
-    }
-
-}
+public record AssociacaoEntradaDTO(
+        @NotNull(message = "ID do cardapio deve ser enviada") @Min(1) Long idCardapio,
+        @Min(1) @NotNull(message = "ID do produto deve ser enviada") Long idProduto,
+        @Min(0) BigDecimal precoCustomizado,
+        @Min(0) Integer quantidadeCustomizada,
+        String descricaoCustomizada,
+        Boolean disponibilidadeCustomizada,
+        String observacao
+) {}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/entrada/CriarCardapioDTO.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/entrada/CriarCardapioDTO.java
@@ -3,31 +3,15 @@ package com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
 
 import java.time.LocalDate;
 
-@Getter
-public class CriarCardapioDTO {
-    @NotBlank(message = "O Nome não pode ser vazio")
-    private final String nome;
-    @NotBlank(message = "A descrição não pode ser vazia")
-    private final String descricao;
-    @NotNull(message = "A disponibilidade do cardápio deve ser preenchida")
-    private final Boolean disponibilidade;
-    @NotNull(message = "A Data do cardápio deve ser preenchida")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private final LocalDate dataInicio;
-    @NotNull(message = "A Data do cardápio deve ser preenchida")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private final LocalDate dataFim;
-
-    public CriarCardapioDTO(String nome, String descricao, Boolean disponibilidade, LocalDate dataInicio, LocalDate dataFim) {
-        this.nome = nome;
-        this.descricao = descricao;
-        this.disponibilidade = disponibilidade;
-        this.dataInicio = dataInicio;
-        this.dataFim = dataFim;
-    }
-
-}
+public record CriarCardapioDTO(
+        @NotBlank(message = "O Nome não pode ser vazio") String nome,
+        @NotBlank(message = "A descrição não pode ser vazia") String descricao,
+        @NotNull(message = "A disponibilidade do cardápio deve ser preenchida") Boolean disponibilidade,
+        @NotNull(message = "A Data do cardápio deve ser preenchida")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate dataInicio,
+        @NotNull(message = "A Data do cardápio deve ser preenchida")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate dataFim
+) {}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/saida/AssociacaoFeitaRespostaDTO.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/saida/AssociacaoFeitaRespostaDTO.java
@@ -1,32 +1,16 @@
 package com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida;
 
 import com.restaurante01.api_restaurante.modulos.produto.api.dto.entrada.ProdutoDTO;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.math.BigDecimal;
 
-@Setter
-@Getter
-public class AssociacaoFeitaRespostaDTO {
-    private String message;
-    private CardapioDTO cardapioDTO;
-    private ProdutoDTO produtoDTO;
-    private BigDecimal precoCustomizado;
-    private Integer quantidadeCustomizada;
-    private String descricaoCustomizada;
-    private Boolean disponibilidadeCustomizada;
-    private String observacao;
-
-    public AssociacaoFeitaRespostaDTO(String message, CardapioDTO cardapioDTO, ProdutoDTO produtoDTO, BigDecimal precoCustomizado, Integer quantidadeCustomizada, Boolean disponibilidadeCustomizada, String observacao, String descricaoCustomizada) {
-        this.message = message;
-        this.cardapioDTO = cardapioDTO;
-        this.produtoDTO = produtoDTO;
-        this.precoCustomizado = precoCustomizado;
-        this.quantidadeCustomizada = quantidadeCustomizada;
-        this.disponibilidadeCustomizada = disponibilidadeCustomizada;
-        this.observacao = observacao;
-        this.descricaoCustomizada = descricaoCustomizada;
-    }
-
-}
+public record AssociacaoFeitaRespostaDTO(
+        String message,
+        CardapioDTO cardapioDTO,
+        ProdutoDTO produtoDTO,
+        BigDecimal precoCustomizado,
+        Integer quantidadeCustomizada,
+        Boolean disponibilidadeCustomizada,
+        String observacao,
+        String descricaoCustomizada
+) {}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/saida/AssociacoesDTO.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/api/dto/saida/AssociacoesDTO.java
@@ -1,35 +1,16 @@
 package com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida;
-import com.restaurante01.api_restaurante.modulos.produto.api.dto.saida.ProdutoCustomDTO;
-import lombok.Getter;
-import lombok.Setter;
 
+import com.restaurante01.api_restaurante.modulos.produto.api.dto.saida.ProdutoCustomDTO;
 
 import java.time.LocalDate;
 import java.util.List;
 
-
-@Setter
-@Getter
-public class AssociacoesDTO {
-    private Long id;
-    private String nome;
-    private String descricao;
-    private Boolean disponibilidade;
-    private LocalDate dataInicio;
-    private LocalDate dataFim;
-
-    private List<ProdutoCustomDTO> produtos;
-
-    public AssociacoesDTO(){}
-    public AssociacoesDTO(Long id, String nome, String descricao, Boolean disponibilidade,
-                          LocalDate dataInicio, LocalDate dataFim, List<ProdutoCustomDTO> produtos) {
-        this.id = id;
-        this.nome = nome;
-        this.descricao = descricao;
-        this.disponibilidade = disponibilidade;
-        this.dataInicio = dataInicio;
-        this.dataFim = dataFim;
-        this.produtos = produtos;
-    }
-
-}
+public record AssociacoesDTO(
+        Long id,
+        String nome,
+        String descricao,
+        Boolean disponibilidade,
+        LocalDate dataInicio,
+        LocalDate dataFim,
+        List<ProdutoCustomDTO> produtos
+) {}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/casodeuso/associacao/casodeuso/AssociarProdutoAoCardapioCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/casodeuso/associacao/casodeuso/AssociarProdutoAoCardapioCasoDeUso.java
@@ -37,12 +37,12 @@ public class AssociarProdutoAoCardapioCasoDeUso {
 
     @Transactional
     public AssociacaoFeitaRespostaDTO executar(AssociacaoEntradaDTO dto) {
-        if(repository.existeAssociacao(dto.getIdCardapio(), dto.getIdProduto())){
+        if(repository.existeAssociacao(dto.idCardapio(), dto.idProduto())){
             throw new AssociacaoExistenteCardapioProdutoExcecao("Associação já existe");
         }
         validator.validarCardapioProdutoAssociacaoEntradaDTO(dto);
-        Produto produto = produtoPorta.obterProdutoPorId(dto.getIdProduto());
-        Cardapio cardapio = cardapioPorta.buscarCardapioPorId(dto.getIdCardapio());
+        Produto produto = produtoPorta.obterProdutoPorId(dto.idProduto());
+        Cardapio cardapio = cardapioPorta.buscarCardapioPorId(dto.idCardapio());
         Associacao novaAssociacao = mapper.mapearCardapioProduto(produto, cardapio, dto);
         repository.save(novaAssociacao);
         return mapper.mapearCardapioProdutoAssociacaoDTO(novaAssociacao);

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/casodeuso/associacao/casodeuso/AtualizarCamposCustomDaAssociacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/casodeuso/associacao/casodeuso/AtualizarCamposCustomDaAssociacaoCasoDeUso.java
@@ -25,7 +25,7 @@ public class AtualizarCamposCustomDaAssociacaoCasoDeUso {
 
     @Transactional
     public AssociacaoFeitaRespostaDTO executar(AssociacaoEntradaDTO dto) {
-        Associacao associacaoExistente = encontrarCardapioProduto(dto.getIdCardapio(), dto.getIdProduto());
+        Associacao associacaoExistente = encontrarCardapioProduto(dto.idCardapio(), dto.idProduto());
         validator.validarCardapioProdutoAssociacaoEntradaDTO(dto);
         Associacao atualizada = mapper.mapearCamposCustom(associacaoExistente, dto);
         repository.save(atualizada);

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/casodeuso/associacao/casodeuso/ListarAssociacaoPorCardapioIdCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/casodeuso/associacao/casodeuso/ListarAssociacaoPorCardapioIdCasoDeUso.java
@@ -1,10 +1,13 @@
 package com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso;
 
-import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada.AssociacaoDTO;
+import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida.AssociacoesDTO;
 import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.mapeador.associacao.mapeador.CardapioProdutoMapeador;
+import com.restaurante01.api_restaurante.modulos.cardapio.dominio.entidade.Associacao;
 import com.restaurante01.api_restaurante.modulos.cardapio.dominio.excecao.AssociacaoNaoExisteExcecao;
 import com.restaurante01.api_restaurante.modulos.cardapio.dominio.repositorio.CardapioProdutoRepositorio;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class ListarAssociacaoPorCardapioIdCasoDeUso {
@@ -17,9 +20,11 @@ public class ListarAssociacaoPorCardapioIdCasoDeUso {
         this.mapper = mapper;
     }
 
-    public AssociacaoDTO executar(long idCardapio) {
-        return repository.findByCardapioId(idCardapio)
-                .map(mapper::mapearUmaEntidadeParaDTO)
-                .orElseThrow(() -> new AssociacaoNaoExisteExcecao("Não existe associação para o cardápio informado"));
+    public AssociacoesDTO executar(long idCardapio) {
+        List<Associacao> associacoes = repository.findByCardapioId(idCardapio);
+        if (associacoes.isEmpty()) {
+            throw new AssociacaoNaoExisteExcecao("Não existe associação para o cardápio informado");
+        }
+        return mapper.mapearCardapioComListaDeProduto(associacoes).get(0);
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/mapeador/CardapioMapeador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/mapeador/CardapioMapeador.java
@@ -33,11 +33,11 @@ public class CardapioMapeador extends AbstractMapper<Cardapio, CardapioDTO> {
     }
     public Cardapio mapearCardapioCreateParaEntidade(CriarCardapioDTO criarCardapioDTO){
         Cardapio cardapio = new Cardapio();
-        cardapio.setNome(FormatarString.limparEspacos(criarCardapioDTO.getNome()));
-        cardapio.setDescricao(FormatarString.limparEspacos(criarCardapioDTO.getDescricao()));
-        cardapio.setDisponibilidade(criarCardapioDTO.getDisponibilidade());
-        cardapio.setDataInicio(criarCardapioDTO.getDataInicio());
-        cardapio.setDataFim(criarCardapioDTO.getDataFim());
+        cardapio.setNome(FormatarString.limparEspacos(criarCardapioDTO.nome()));
+        cardapio.setDescricao(FormatarString.limparEspacos(criarCardapioDTO.descricao()));
+        cardapio.setDisponibilidade(criarCardapioDTO.disponibilidade());
+        cardapio.setDataInicio(criarCardapioDTO.dataInicio());
+        cardapio.setDataFim(criarCardapioDTO.dataFim());
         return cardapio;
     }
     public Cardapio atualizarCampos(Cardapio cardapioExistente , CardapioDTO cardapioAtualizado){
@@ -52,11 +52,11 @@ public class CardapioMapeador extends AbstractMapper<Cardapio, CardapioDTO> {
     public CardapioDTO mapearCardapioCreateParaCardapioDTO(CriarCardapioDTO criarCardapioDTO) {
         return new CardapioDTO(
                 null,
-                criarCardapioDTO.getNome(),
-                criarCardapioDTO.getDescricao(),
-                criarCardapioDTO.getDisponibilidade(),
-                criarCardapioDTO.getDataInicio(),
-                criarCardapioDTO.getDataFim()
+                criarCardapioDTO.nome(),
+                criarCardapioDTO.descricao(),
+                criarCardapioDTO.disponibilidade(),
+                criarCardapioDTO.dataInicio(),
+                criarCardapioDTO.dataFim()
         );
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/mapeador/associacao/mapeador/CardapioProdutoMapeador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/mapeador/associacao/mapeador/CardapioProdutoMapeador.java
@@ -29,7 +29,7 @@ public class CardapioProdutoMapeador extends AbstractMapper<Associacao, Associac
     }
 
     @Override
-    public AssociacaoDTO mapearUmaEntidadeParaDTO (Associacao associacao) {
+    public AssociacaoDTO mapearUmaEntidadeParaDTO(Associacao associacao) {
         return new AssociacaoDTO(
                 associacao.getId(),
                 cardapioMapeador.mapearUmaEntidadeParaDTO(associacao.getCardapio()),
@@ -41,21 +41,22 @@ public class CardapioProdutoMapeador extends AbstractMapper<Associacao, Associac
                 associacao.getObservacao()
         );
     }
-    @Override
-    public Associacao mapearUmaDtoParaEntidade (AssociacaoDTO associacaoDTO) {
-        return new Associacao(
-                associacaoDTO.getId(),
-                cardapioMapeador.mapearUmaDtoParaEntidade(associacaoDTO.getCardapio()),
-                produtoMapeador.mapearUmaDtoParaEntidade(associacaoDTO.getProduto()),
-                associacaoDTO.getPrecoCustomizado(),
-                associacaoDTO.getQuantidadeCustomizada(),
-                associacaoDTO.getDescricaoCustomizada(),
-                associacaoDTO.getDisponibilidadeCustomizada(),
-                associacaoDTO.getObservacao()
 
+    @Override
+    public Associacao mapearUmaDtoParaEntidade(AssociacaoDTO associacaoDTO) {
+        return new Associacao(
+                associacaoDTO.id(),
+                cardapioMapeador.mapearUmaDtoParaEntidade(associacaoDTO.cardapio()),
+                produtoMapeador.mapearUmaDtoParaEntidade(associacaoDTO.produto()),
+                associacaoDTO.precoCustomizado(),
+                associacaoDTO.quantidadeCustomizada(),
+                associacaoDTO.descricaoCustomizada(),
+                associacaoDTO.disponibilidadeCustomizada(),
+                associacaoDTO.observacao()
         );
     }
-    public AssociacaoFeitaRespostaDTO mapearCardapioProdutoAssociacaoDTO(Associacao associacao){
+
+    public AssociacaoFeitaRespostaDTO mapearCardapioProdutoAssociacaoDTO(Associacao associacao) {
         return new AssociacaoFeitaRespostaDTO(
                 "O produto: " + associacao.getProduto().getNome() + " foi associado ao " + associacao.getCardapio().getNome(),
                 cardapioMapeador.mapearUmaEntidadeParaDTO(associacao.getCardapio()),
@@ -68,65 +69,63 @@ public class CardapioProdutoMapeador extends AbstractMapper<Associacao, Associac
         );
     }
 
-    public List<AssociacoesDTO> mapearCardapioComListaDeProduto(List<Associacao> listaDeAssociacao){
+    public List<AssociacoesDTO> mapearCardapioComListaDeProduto(List<Associacao> listaDeAssociacao) {
         Map<Long, AssociacoesDTO> map = new LinkedHashMap<>();
-        for(Associacao cp : listaDeAssociacao){
+        for (Associacao cp : listaDeAssociacao) {
             Cardapio cardapio = cp.getCardapio();
-            AssociacoesDTO dto = map.computeIfAbsent(cardapio.getId(), id ->{
-                return mapearCardapioProdutoDTO(cardapio);
-        });
-            Produto produto = cp.getProduto();
-            ProdutoCustomDTO produtoCustomDTO = criarProdutoCustomDTO(produto, cp);
-            dto.getProdutos().add(produtoCustomDTO);
-    }
+            AssociacoesDTO dto = map.computeIfAbsent(cardapio.getId(), id -> mapearCardapioProdutoDTO(cardapio));
+            dto.produtos().add(criarProdutoCustomDTO(cp.getProduto(), cp));
+        }
         return new ArrayList<>(map.values());
     }
-    public Associacao mapearCardapioProduto(Produto produto, Cardapio cardapio, AssociacaoEntradaDTO associacaoEntradaDTO){
+
+    public Associacao mapearCardapioProduto(Produto produto, Cardapio cardapio, AssociacaoEntradaDTO dto) {
         return new Associacao(
                 null,
                 cardapio,
                 produto,
-                associacaoEntradaDTO.getPrecoCustomizado(),
-                associacaoEntradaDTO.getQuantidadeCustomizada(),
-                associacaoEntradaDTO.getDescricaoCustomizada(),
-                associacaoEntradaDTO.getDisponibilidadeCustomizada(),
-                associacaoEntradaDTO.getObservacao()
+                dto.precoCustomizado(),
+                dto.quantidadeCustomizada(),
+                dto.descricaoCustomizada(),
+                dto.disponibilidadeCustomizada(),
+                dto.observacao()
         );
     }
+
     public AssociacoesDTO mapearCardapioProdutoDTO(Cardapio cardapio) {
-        AssociacoesDTO cardapioProdutoDTO = new AssociacoesDTO();
-        cardapioProdutoDTO.setId(cardapio.getId());
-        cardapioProdutoDTO.setNome(cardapio.getNome());
-        cardapioProdutoDTO.setDescricao(cardapio.getDescricao());
-        cardapioProdutoDTO.setDisponibilidade(cardapio.getDisponibilidade());
-        cardapioProdutoDTO.setDataInicio(cardapio.getDataInicio());
-        cardapioProdutoDTO.setDataFim(cardapio.getDataFim());
-        cardapioProdutoDTO.setProdutos(new ArrayList<>());
-        return cardapioProdutoDTO;
+        return new AssociacoesDTO(
+                cardapio.getId(),
+                cardapio.getNome(),
+                cardapio.getDescricao(),
+                cardapio.getDisponibilidade(),
+                cardapio.getDataInicio(),
+                cardapio.getDataFim(),
+                new ArrayList<>()
+        );
     }
-    public ProdutoCustomDTO criarProdutoCustomDTO (Produto produto, Associacao associacao){
-        ProdutoCustomDTO produtoCustomDTO = new ProdutoCustomDTO();
-        produtoCustomDTO.setIdProduto(produto.getId());
-        produtoCustomDTO.setNome(produto.getNome());
-        produtoCustomDTO.setDescricao(produto.getDescricao());
-        produtoCustomDTO.setPreco(produto.getPreco());
-        produtoCustomDTO.setQuantidadeAtual(produto.getQuantidadeAtual());
-        produtoCustomDTO.setDisponibilidade(produto.getDisponibilidade());
-        produtoCustomDTO.setPrecoCustomizado(associacao.getPrecoCustomizado());
-        produtoCustomDTO.setDescricaoCustomizada(associacao.getDescricaoCustomizada());
-        produtoCustomDTO.setQuantidadeCustomizada(associacao.getQuantidadeCustomizada());
-        produtoCustomDTO.setDisponibilidadeCustomizada(associacao.getDisponibilidadeCustomizada());
-        produtoCustomDTO.setObservacao(associacao.getObservacao());
-        return produtoCustomDTO;
+
+    public ProdutoCustomDTO criarProdutoCustomDTO(Produto produto, Associacao associacao) {
+        return new ProdutoCustomDTO(
+                produto.getId(),
+                produto.getNome(),
+                produto.getDescricao(),
+                produto.getPreco(),
+                produto.getQuantidadeAtual(),
+                produto.getDisponibilidade(),
+                associacao.getPrecoCustomizado(),
+                associacao.getQuantidadeCustomizada() != null ? associacao.getQuantidadeCustomizada() : 0,
+                associacao.getDescricaoCustomizada(),
+                associacao.getDisponibilidadeCustomizada(),
+                associacao.getObservacao()
+        );
     }
-    public Associacao mapearCamposCustom(Associacao associacao, AssociacaoEntradaDTO dto){
-        associacao.setPrecoCustomizado(dto.getPrecoCustomizado());
-        associacao.setObservacao(dto.getObservacao());
-        associacao.setDescricaoCustomizada(dto.getDescricaoCustomizada());
-        associacao.setDisponibilidadeCustomizada(dto.getDisponibilidadeCustomizada());
-        associacao.setQuantidadeCustomizada(dto.getQuantidadeCustomizada());
+
+    public Associacao mapearCamposCustom(Associacao associacao, AssociacaoEntradaDTO dto) {
+        associacao.setPrecoCustomizado(dto.precoCustomizado());
+        associacao.setObservacao(dto.observacao());
+        associacao.setDescricaoCustomizada(dto.descricaoCustomizada());
+        associacao.setDisponibilidadeCustomizada(dto.disponibilidadeCustomizada());
+        associacao.setQuantidadeCustomizada(dto.quantidadeCustomizada());
         return associacao;
     }
-
-
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/validador/associacao/validador/CardapioProdutoValidador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/aplicacao/validador/associacao/validador/CardapioProdutoValidador.java
@@ -13,13 +13,13 @@ public class CardapioProdutoValidador {
 
 
     public void validarCardapioProdutoAssociacaoEntradaDTO(AssociacaoEntradaDTO dto){
-        if(dto.getPrecoCustomizado() != null && dto.getPrecoCustomizado().compareTo(BigDecimal.ZERO) < 0){
+        if(dto.precoCustomizado() != null && dto.precoCustomizado().compareTo(BigDecimal.ZERO) < 0){
             throw new PrecoProdutoNegativoException("O preço customizado não pode ser negativo");
         }
-        if(dto.getQuantidadeCustomizada() < 0){
+        if(dto.quantidadeCustomizada() != null && dto.quantidadeCustomizada() < 0){
             throw new ProdutoQntdNegativa("A quantidade customizada não pode ser negativa");
         }
-        if(dto.getDescricaoCustomizada() != null && dto.getDescricaoCustomizada().length() < 10){
+        if(dto.descricaoCustomizada() != null && dto.descricaoCustomizada().length() < 10){
             throw new ProdutoDescricaoInvalidaExcpetion("Descrição deve conter mais de 10 caracteres");
         }
     }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/dominio/repositorio/CardapioProdutoRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/dominio/repositorio/CardapioProdutoRepositorio.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CardapioProdutoRepositorio {
-    Optional<Associacao> findByCardapioId(long id);
+    List<Associacao> findByCardapioId(long id);
     Optional<Associacao> findByCardapioIdAndProdutoId(long cardapioId, long produtoId);
     boolean existeAssociacao(long idCardapio, long idProduto);
     void deletarAssociacao(long idCardapio, long idProduto);

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/infraestrutura/adaptador/AssociacaoJpaAdaptador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/infraestrutura/adaptador/AssociacaoJpaAdaptador.java
@@ -18,7 +18,7 @@ public class AssociacaoJpaAdaptador implements CardapioProdutoRepositorio {
     }
 
     @Override
-    public Optional<Associacao> findByCardapioId(long id) {
+    public List<Associacao> findByCardapioId(long id) {
         return jpa.findByCardapioId(id);
     }
 

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/infraestrutura/persistencia/AssociacaoJPA.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/cardapio/infraestrutura/persistencia/AssociacaoJPA.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 @Repository
 public interface AssociacaoJPA extends JpaRepository<Associacao, Long> {
 
-    Optional <Associacao> findByCardapioId(long id);
+    List<Associacao> findByCardapioId(long id);
     Optional<Associacao> findByCardapioIdAndProdutoId(long cardapioId, long produtoId);
     @Query(value = "SELECT EXISTS (SELECT 1 FROM cardapio_produto cp WHERE cp.cardapio_id = :idCardapio AND cp.produto_id = :idProduto)", nativeQuery = true)
     boolean encontrarProdutoCardapio(@Param("idCardapio") long idCardapio, @Param("idProduto") long idProduto);

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/publico/AssociacaoPublicoControladorTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/cardapio/api/controlador/publico/AssociacaoPublicoControladorTest.java
@@ -3,7 +3,6 @@ package com.restaurante01.api_restaurante.modulos.cardapio.api.controlador.publi
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.restaurante01.api_restaurante.infraestrutura.autenticacao.service.ServicoAutorizacao;
 import com.restaurante01.api_restaurante.infraestrutura.jwt.JwtProvider;
-import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.entrada.AssociacaoDTO;
 import com.restaurante01.api_restaurante.modulos.cardapio.api.dto.saida.AssociacoesDTO;
 import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.ListarAssociacaoPorCardapioIdCasoDeUso;
 import com.restaurante01.api_restaurante.modulos.cardapio.aplicacao.casodeuso.associacao.casodeuso.ListarTodasAssociacoesCasoDeUso;
@@ -17,17 +16,15 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(CardapioProdutoPublicoControlador.class)
+@WebMvcTest(AssociacaoPublicoControlador.class)
 @Import(SecurityConfigurations.class)
-class CardapioProdutoPublicoControladorTest {
+class AssociacaoPublicoControladorTest {
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
@@ -56,7 +53,7 @@ class CardapioProdutoPublicoControladorTest {
     @Test
     @DisplayName("Deve retornar associação de um cardápio pelo ID sem autenticação")
     void deveRetornarAssociacaoPorCardapioId() throws Exception {
-        var associacaoEsperada = Instancio.create(AssociacaoDTO.class);
+        var associacaoEsperada = Instancio.create(AssociacoesDTO.class);
         when(listarPorCardapioId.executar(anyLong())).thenReturn(associacaoEsperada);
 
         mockMvc.perform(get("/cardapio-produto/publico/cardapio/1"))

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/cardapioproduto/aplicacao/casodeuso/AssociarProdutoAoCardapioCasoDeUsoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/cardapioproduto/aplicacao/casodeuso/AssociarProdutoAoCardapioCasoDeUsoTest.java
@@ -98,9 +98,9 @@ class AssociarProdutoAoCardapioCasoDeUsoTest {
                 "Nenhuma Descrição Customizada"
         );
 
-        when(cardapioProdutoRepositorio.existeAssociacao(dto.getIdCardapio(), dto.getIdProduto())).thenReturn(false);
-        when(obterProdutoPorIdCasoDeUso.obterProdutoPorId(dto.getIdProduto())).thenReturn(produto);
-        when(buscarCardapioPorIdCasoDeUso.buscarCardapioPorId(dto.getIdCardapio())).thenReturn(cardapio);
+        when(cardapioProdutoRepositorio.existeAssociacao(dto.idCardapio(), dto.idProduto())).thenReturn(false);
+        when(obterProdutoPorIdCasoDeUso.obterProdutoPorId(dto.idProduto())).thenReturn(produto);
+        when(buscarCardapioPorIdCasoDeUso.buscarCardapioPorId(dto.idCardapio())).thenReturn(cardapio);
         when(cardapioProdutoMapeador.mapearCardapioProduto(produto, cardapio, dto)).thenReturn(novaAssociacao);
         when(cardapioProdutoMapeador.mapearCardapioProdutoAssociacaoDTO(novaAssociacao)).thenReturn(associacaoFeitaRespostaDTO);
 
@@ -126,7 +126,7 @@ class AssociarProdutoAoCardapioCasoDeUsoTest {
                 "teste descricao teste",
                 true,
                 "teste de observação");
-        when(cardapioProdutoRepositorio.existeAssociacao(dto.getIdCardapio(), dto.getIdProduto())).thenReturn(true);
+        when(cardapioProdutoRepositorio.existeAssociacao(dto.idCardapio(), dto.idProduto())).thenReturn(true);
 
 
         assertThatThrownBy(() -> casoDeUso.executar(dto))


### PR DESCRIPTION
## Resumo

Esta PR resolve o bug reportado na issue #22 e aproveita a oportunidade para modernizar os DTOs do módulo `cardapio-produto`, convertendo-os de classes com Lombok para Java Records.

---

## 🐛 Bug Fix — Issue #22

**Problema:** `GET /cardapio-produto/publico/cardapio/{idCardapio}` retornava erro inesperado quando o cardápio possuía mais de um produto associado.

**Causa raiz:** O método `findByCardapioId` retornava `Optional<Associacao>` (um único resultado), mas a relação entre cardápio e produto é 1:N. Quando existiam 2 ou mais produtos, o Spring Data JPA lançava `IncorrectResultSizeDataAccessException`.

**Correção aplicada em 4 camadas:**
- `AssociacaoJPA`: `Optional<Associacao>` → `List<Associacao>`
- `CardapioProdutoRepositorio`: mesma alteração na interface de domínio
- `AssociacaoJpaAdaptador`: atualizado para retornar `List<Associacao>`
- `ListarAssociacaoPorCardapioIdCasoDeUso`: agora usa `mapearCardapioComListaDeProduto` e retorna `AssociacoesDTO` com todos os produtos do cardápio agrupados

O JSON de resposta preserva o formato achatado: dados do cardápio na raiz + lista de produtos com customizações, sem repetição de dados.

Closes #22

---

## ♻️ Refactor — DTOs convertidos para Java Records

Aproveitando a alteração no módulo, os DTOs foram modernizados com o recurso nativo do Java 16+.

**5 classes convertidas para records:**

| DTO | Pacote |
|-----|--------|
| `AssociacaoDTO` | `dto/entrada` |
| `AssociacaoEntradaDTO` | `dto/entrada` |
| `CriarCardapioDTO` | `dto/entrada` |
| `AssociacaoFeitaRespostaDTO` | `dto/saida` |
| `AssociacoesDTO` | `dto/saida` |

**Benefícios:**
- Eliminação do Lombok (`@Getter`, `@Setter`) nos DTOs — imutabilidade garantida pelo compilador
- Redução de ~95 linhas de boilerplate
- Acessores idiomáticos (`nome()` ao invés de `getNome()`)
- Equals/hashCode/toString gerados automaticamente pelo compilador

**Consumidores atualizados:** `CardapioMapeador`, `CardapioProdutoMapeador`, `AssociarProdutoAoCardapioCasoDeUso`, `AtualizarCamposCustomDaAssociacaoCasoDeUso`, `CardapioProdutoValidador` e testes.

---

## 🧹 Melhorias adicionais no CardapioProdutoMapeador

- `mapearCardapioProdutoDTO`: substituídos 7 setters pelo construtor canônico do record `AssociacoesDTO`
- `criarProdutoCustomDTO`: substituídas 11 chamadas de setter pelo construtor canônico de `ProdutoCustomDTO`
- Loop em `mapearCardapioComListaDeProduto` simplificado

## 🛡️ Fix de NPE no CardapioProdutoValidador

Adicionado null-check em `quantidadeCustomizada` antes da comparação numérica — o campo é opcional e a ausência de verificação poderia causar `NullPointerException` em runtime.

---

## Plano de testes

- [x] Todos os 132 testes existentes passando (`BUILD SUCCESS`)
- [x] Testes do controller público (`AssociacaoPublicoControladorTest`) atualizados
- [x] Testes do use case (`AssociarProdutoAoCardapioCasoDeUsoTest`) atualizados
- [x] Validar manualmente `GET /cardapio-produto/publico/cardapio/{id}` com cardápio possuindo múltiplos produtos
- [x] Validar `GET /cardapio-produto/publico/todas` para garantir que o agrupamento continua correto