### PR TITLE
RA-7: Ciclo de atualização de avaliação

### DIFF
--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/configs/scheduler/IntervaloScheduler.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/configs/scheduler/IntervaloScheduler.java
@@ -1,0 +1,28 @@
+package com.restaurante01.api_restaurante.infraestrutura.configs.scheduler;
+
+public enum IntervaloScheduler {
+
+    UM_MINUTO        (1),
+    CINCO_MINUTOS    (5),
+    DEZ_MINUTOS      (10),
+    TRINTA_MINUTOS   (30),
+    UMA_HORA         (60),
+    DUAS_HORAS       (120),
+    SEIS_HORAS       (360),
+    DOZE_HORAS       (720),
+    UM_DIA           (1440);
+
+    private final long minutos;
+
+    IntervaloScheduler(long minutos) {
+        this.minutos = minutos;
+    }
+
+    public long emMilissegundos() {
+        return minutos * 60 * 1000;
+    }
+
+    public long emSegundos() {
+        return minutos * 60;
+    }
+}

--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/inicializador/DatabaseSeeder.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/inicializador/DatabaseSeeder.java
@@ -198,6 +198,18 @@ public class DatabaseSeeder implements CommandLineRunner {
         entityManager.persist(p6);
         avancarAte(p6, StatusPedido.ENTREGUE);
 
+        Pedido p21 = Pedido.criar(principal.getId(), infoMaria, endMaria);
+        p21.adicionarItem(item(p21, 1, batataFrita,  aBatataP,       ""));
+        p21.adicionarItem(item(p21, 1, refrigerante, aRefrigeranteP, ""));
+        entityManager.persist(p21);
+        avancarAte(p21, StatusPedido.ENTREGUE);
+
+        Pedido p22 = Pedido.criar(fds.getId(), infoJoao, endJoao);
+        p22.adicionarItem(item(p22, 1, milkShake, aMilkShakeF, ""));
+        p22.adicionarItem(item(p22, 1, brownie,   aBrownieF,   ""));
+        entityManager.persist(p22);
+        avancarAte(p22, StatusPedido.ENTREGUE);
+
         // --- SAIU PARA ENTREGA ---
 
         Pedido p7 = Pedido.criar(principal.getId(), infoMaria, endMaria);
@@ -357,6 +369,23 @@ public class DatabaseSeeder implements CommandLineRunner {
         av6.foiEnviadaAoCliente();
         concluirAvaliacao(av6, new NotaAvaliacao(5), new ComentarioAvaliacao("Pedido excelente! Tudo chegou no prazo e bem fresquinho."));
         entityManager.persist(av6);
+
+        // 7. DISPONIVEL — PRIMEIRA_TENTATIVA há 4 dias → candidata à renotificação (regra: > 3 dias)
+        Avaliacao av7 = Avaliacao.criar(p21.getId(), maria.getId(), List.of(
+                avalItem(batataFrita), avalItem(refrigerante)));
+        av7.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+        av7.foiEnviadaAoCliente();
+        setarCampo(av7, "dataCriacao", LocalDateTime.now().minusDays(4));
+        entityManager.persist(av7);
+
+        // 8. DISPONIVEL — SEGUNDA_TENTATIVA há 7 dias → candidata à renotificação (regra: > 6 dias)
+        Avaliacao av8 = Avaliacao.criar(p22.getId(), joao.getId(), List.of(
+                avalItem(milkShake), avalItem(brownie)));
+        av8.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+        av8.foiEnviadaAoCliente();
+        av8.foiEnviadaAoCliente();
+        setarCampo(av8, "dataCriacao", LocalDateTime.now().minusDays(7));
+        entityManager.persist(av8);
 
         entityManager.flush();
     }

--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/inicializador/DatabaseSeeder.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/inicializador/DatabaseSeeder.java
@@ -1,5 +1,10 @@
 package com.restaurante01.api_restaurante.infraestrutura.inicializador;
 
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.AvaliacaoItem;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.ComentarioAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.NotaAvaliacao;
 import com.restaurante01.api_restaurante.modulos.cupom.dominio.entidade.Cupom;
 import com.restaurante01.api_restaurante.modulos.cupom.dominio.entidade.PeriodoCupom;
 import com.restaurante01.api_restaurante.modulos.cupom.dominio.entidade.RegraRecorrencia;
@@ -24,8 +29,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
@@ -300,6 +308,55 @@ public class DatabaseSeeder implements CommandLineRunner {
                 TipoDesconto.VALOR, RegraRecorrencia.TRINTA_DIAS,
                 new BigDecimal("5"), new BigDecimal("45"), new BigDecimal("100")));
 
+        // -------------------------------------------------------------------------
+        // AVALIAÇÕES (6 cenários)
+        // -------------------------------------------------------------------------
+
+        // 1. PENDENTE — criada mas notificação ainda não enviada ao cliente
+        Avaliacao av1 = Avaliacao.criar(p1.getId(), maria.getId(), List.of(
+                avalItem(hamburguer), avalItem(refrigerante)));
+        entityManager.persist(av1);
+
+        // 2. DISPONIVEL — notificação enviada, aguardando resposta, prazo válido
+        Avaliacao av2 = Avaliacao.criar(p2.getId(), maria.getId(), List.of(
+                avalItem(frango), avalItem(suco)));
+        av2.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+        av2.foiEnviadaAoCliente();
+        entityManager.persist(av2);
+
+        // 3. DISPONIVEL + DATA EXPIRADA — deve ser capturada e expirada pelo scheduler
+        Avaliacao av3 = Avaliacao.criar(p3.getId(), joao.getId(), List.of(
+                avalItem(pizza), avalItem(batataFrita), avalItem(refrigerante)));
+        av3.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+        av3.foiEnviadaAoCliente();
+        setarCampo(av3, "dataExpiracao", LocalDateTime.now().minusDays(10));
+        entityManager.persist(av3);
+
+        // 4. DISPONIVEL + DATA EXPIRADA — outro candidato para o scheduler
+        Avaliacao av4 = Avaliacao.criar(p4.getId(), joao.getId(), List.of(
+                avalItem(hamburguer), avalItem(milkShake)));
+        av4.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+        av4.foiEnviadaAoCliente();
+        setarCampo(av4, "dataExpiracao", LocalDateTime.now().minusDays(3));
+        entityManager.persist(av4);
+
+        // 5. CONCLUIDA — voto em branco (sem nota, sem comentário) → NAO_AVALIADO
+        Avaliacao av5 = Avaliacao.criar(p5.getId(), maria.getId(), List.of(
+                avalItem(wrap), avalItem(suco), avalItem(brownie)));
+        av5.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+        av5.foiEnviadaAoCliente();
+        concluirAvaliacao(av5, null, null);
+        entityManager.persist(av5);
+
+        // 6. CONCLUIDA COMPLETA — nota 5, SATISFEITO, com comentário e itens avaliados
+        Avaliacao av6 = Avaliacao.criar(p6.getId(), joao.getId(), List.of(
+                avalItemComNota(salada, 5, "Salada fresquíssima, muito bem temperada!"),
+                avalItemComNota(suco, 4, null)));
+        av6.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+        av6.foiEnviadaAoCliente();
+        concluirAvaliacao(av6, new NotaAvaliacao(5), new ComentarioAvaliacao("Pedido excelente! Tudo chegou no prazo e bem fresquinho."));
+        entityManager.persist(av6);
+
         entityManager.flush();
     }
 
@@ -354,6 +411,37 @@ public class DatabaseSeeder implements CommandLineRunner {
         for (StatusPedido status : fluxo) {
             pedido.mudarStatus(status);
             if (status == destino) break;
+        }
+    }
+
+    private AvaliacaoItem avalItem(Produto produto) {
+        return AvaliacaoItem.criar(produto.getId(), produto.getNome(), null, null);
+    }
+
+    private AvaliacaoItem avalItemComNota(Produto produto, int nota, String comentario) {
+        return AvaliacaoItem.criar(
+                produto.getId(), produto.getNome(),
+                new NotaAvaliacao(nota),
+                comentario != null ? new ComentarioAvaliacao(comentario) : null);
+    }
+
+    private void setarCampo(Object obj, String nomeCampo, Object valor) {
+        try {
+            Field field = obj.getClass().getDeclaredField(nomeCampo);
+            field.setAccessible(true);
+            field.set(obj, valor);
+        } catch (Exception e) {
+            throw new RuntimeException("Seeder: erro ao setar campo '" + nomeCampo + "'", e);
+        }
+    }
+
+    private void concluirAvaliacao(Avaliacao avaliacao, NotaAvaliacao nota, ComentarioAvaliacao comentario) {
+        try {
+            Method method = Avaliacao.class.getDeclaredMethod("concluirAvaliacao", NotaAvaliacao.class, ComentarioAvaliacao.class);
+            method.setAccessible(true);
+            method.invoke(avaliacao, nota, comentario);
+        } catch (Exception e) {
+            throw new RuntimeException("Seeder: erro ao invocar concluirAvaliacao", e);
         }
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/inicializador/DatabaseSeeder.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/inicializador/DatabaseSeeder.java
@@ -312,9 +312,10 @@ public class DatabaseSeeder implements CommandLineRunner {
         // AVALIAÇÕES (6 cenários)
         // -------------------------------------------------------------------------
 
-        // 1. PENDENTE — criada mas notificação ainda não enviada ao cliente
+        // 1. PENDENTE — criada 2h atrás para ser capturada pelo scheduler de disponibilização
         Avaliacao av1 = Avaliacao.criar(p1.getId(), maria.getId(), List.of(
                 avalItem(hamburguer), avalItem(refrigerante)));
+        setarCampo(av1, "dataCriacao", LocalDateTime.now().minusHours(2));
         entityManager.persist(av1);
 
         // 2. DISPONIVEL — notificação enviada, aguardando resposta, prazo válido

--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/notificador/NotificadorAvaliacaoAdaptador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/notificador/NotificadorAvaliacaoAdaptador.java
@@ -1,0 +1,16 @@
+package com.restaurante01.api_restaurante.infraestrutura.notificador;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.porta.AvaliacaoNotificadorPorta;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.AvaliacaoParaNotificar;
+import org.springframework.stereotype.Component;
+
+
+//deve chamar serviços de notificação
+@Component
+public class NotificadorAvaliacaoAdaptador implements AvaliacaoNotificadorPorta {
+
+    @Override
+    public void notificarCliente(AvaliacaoParaNotificar avaliacao){
+
+    }
+}

--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/notificador/NotificadorAvaliacaoAdaptador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/notificador/NotificadorAvaliacaoAdaptador.java
@@ -11,6 +11,7 @@ public class NotificadorAvaliacaoAdaptador implements AvaliacaoNotificadorPorta 
 
     @Override
     public void notificarCliente(AvaliacaoParaNotificar avaliacao){
-
+            System.out.println("::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::");
+            System.out.println("Oba, o cliente foi notificado, o pedido dele é: " + avaliacao.pedidoId());
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ConcluirAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ConcluirAvaliacaoCasoDeUso.java
@@ -1,0 +1,23 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.AvaliacaoInvalidaExcecao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ConcluirAvaliacaoCasoDeUso {
+    private final AvaliacaoRepositorio repositorio;
+
+    public void executar(Long id){
+
+    }
+
+    private Avaliacao encontrarAvaliacao(Long id){
+        return repositorio.buscarPorId(id)
+                .orElseThrow(() -> new AvaliacaoInvalidaExcecao("Avaliação com id " + id + " não foi localizada"));
+    }
+}
+

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/DisponibilizarAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/DisponibilizarAvaliacaoCasoDeUso.java
@@ -6,12 +6,14 @@ import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.porta.Avaliac
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.AvaliacaoParaNotificar;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @AllArgsConstructor
 public class DisponibilizarAvaliacaoCasoDeUso {
@@ -26,9 +28,14 @@ public class DisponibilizarAvaliacaoCasoDeUso {
         if (avaliacoes.isEmpty()) return;
 
         avaliacoes.forEach(avaliacao -> {
-            avaliacao.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
-            avaliacao.foiEnviadaAoCliente();
-            notificadorPorta.notificarCliente(new AvaliacaoParaNotificar(avaliacao.getId(), avaliacao.getClienteId(), avaliacao.getPedidoId()));
+            try {
+                avaliacao.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+                avaliacao.foiEnviadaAoCliente();
+                notificadorPorta.notificarCliente(new AvaliacaoParaNotificar(avaliacao.getId(), avaliacao.getClienteId(), avaliacao.getPedidoId()));
+            }
+            catch (Exception e){
+                log.error("Erro ao notificar avaliacao id={}", avaliacao.getId(), e);
+            }
         });
         repositorio.salvarLista(avaliacoes);
     }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/DisponibilizarAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/DisponibilizarAvaliacaoCasoDeUso.java
@@ -1,23 +1,36 @@
 package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
-import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.AvaliacaoInvalidaExcecao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.porta.AvaliacaoNotificadorPorta;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.AvaliacaoParaNotificar;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @AllArgsConstructor
 public class DisponibilizarAvaliacaoCasoDeUso {
     private final AvaliacaoRepositorio repositorio;
+    private final AvaliacaoNotificadorPorta notificadorPorta;
 
-    public void executar(Long id){
+    @Transactional
+    public void executar(){
+        LocalDateTime limite = LocalDateTime.now().minusHours(1);
+        List<Avaliacao> avaliacoes = repositorio.buscarTodasCriadasAte(StatusAvaliacao.PENDENTE, limite);
 
-    }
+        if (avaliacoes.isEmpty()) return;
 
-    private Avaliacao encontrarAvaliacao(Long id){
-        return repositorio.buscarPorId(id)
-                .orElseThrow(() -> new AvaliacaoInvalidaExcecao("Avaliação com id " + id + " não foi localizada"));
+        avaliacoes.forEach(avaliacao -> {
+            avaliacao.mudarStatusAvaliacao(StatusAvaliacao.DISPONIVEL);
+            avaliacao.foiEnviadaAoCliente();
+            notificadorPorta.notificarCliente(new AvaliacaoParaNotificar(avaliacao.getId(), avaliacao.getClienteId(), avaliacao.getPedidoId()));
+        });
+        repositorio.salvarLista(avaliacoes);
     }
 }
 

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/DisponibilizarAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/DisponibilizarAvaliacaoCasoDeUso.java
@@ -1,0 +1,24 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.AvaliacaoInvalidaExcecao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class DisponibilizarAvaliacaoCasoDeUso {
+    private final AvaliacaoRepositorio repositorio;
+
+    public void executar(Long id){
+
+    }
+
+    private Avaliacao encontrarAvaliacao(Long id){
+        return repositorio.buscarPorId(id)
+                .orElseThrow(() -> new AvaliacaoInvalidaExcecao("Avaliação com id " + id + " não foi localizada"));
+    }
+}
+
+

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
@@ -2,10 +2,15 @@ package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
-import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.AvaliacaoInvalidaExcecao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
 
 @Service
 @AllArgsConstructor
@@ -13,13 +18,13 @@ public class ExpirarAvaliacaoCasoDeUso {
 
     private final AvaliacaoRepositorio repositorio;
 
-    public void executar(Long id){
-        Avaliacao avaliacao  = encontrarAvaliacao(id);
-        avaliacao.mudarStatusAvaliacao(StatusAvaliacao.EXPIRADA);
-        repositorio.salvar(avaliacao);
-    }
-     private Avaliacao encontrarAvaliacao(Long id){
-        return repositorio.buscarPorId(id)
-                .orElseThrow(() -> new AvaliacaoInvalidaExcecao("Avaliação com id " + id + " não foi localizada"));
+    @Transactional
+    public void executar(){
+        List<Avaliacao> avaliacoesExpiradas = repositorio.buscarExpiradas(LocalDateTime.now());
+        if(avaliacoesExpiradas.isEmpty()){
+            return;
+        }
+        avaliacoesExpiradas.forEach(avaliacao -> avaliacao.mudarStatusAvaliacao(StatusAvaliacao.EXPIRADA));
+        repositorio.salvarLista(avaliacoesExpiradas);
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
@@ -1,0 +1,25 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.AvaliacaoInvalidaExcecao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ExpirarAvaliacaoCasoDeUso {
+
+    private final AvaliacaoRepositorio repositorio;
+
+    public void executar(Long id){
+        Avaliacao avaliacao  = encontrarAvaliacao(id);
+        avaliacao.mudarStatusAvaliacao(StatusAvaliacao.EXPIRADA);
+        repositorio.salvar(avaliacao);
+    }
+     private Avaliacao encontrarAvaliacao(Long id){
+        return repositorio.buscarPorId(id)
+                .orElseThrow(() -> new AvaliacaoInvalidaExcecao("Avaliação com id " + id + " não foi localizada"));
+    }
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
@@ -20,11 +20,11 @@ public class ExpirarAvaliacaoCasoDeUso {
 
     @Transactional
     public void executar(){
-        List<Avaliacao> avaliacoesExpiradas = repositorio.buscarExpiradas(StatusAvaliacao.DISPONIVEL, LocalDateTime.now());
+        List<Avaliacao> avaliacoesExpiradas = repositorio.buscarTodasCriadasAte(StatusAvaliacao.DISPONIVEL, LocalDateTime.now().minusDays(7));
         if(avaliacoesExpiradas.isEmpty()){
             return;
         }
-        avaliacoesExpiradas.forEach(avaliacao -> avaliacao.mudarStatusAvaliacao(StatusAvaliacao.EXPIRADA));
+        avaliacoesExpiradas.forEach(Avaliacao::expirarAvaliacao);
         repositorio.salvarLista(avaliacoesExpiradas);
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
@@ -20,7 +20,10 @@ public class ExpirarAvaliacaoCasoDeUso {
 
     @Transactional
     public void executar(){
-        List<Avaliacao> avaliacoesExpiradas = repositorio.buscarTodasCriadasAte(StatusAvaliacao.DISPONIVEL, LocalDateTime.now().minusDays(7));
+        List<Avaliacao> avaliacoesExpiradas = repositorio.buscarExpiradas(
+                StatusAvaliacao.DISPONIVEL,
+                LocalDateTime.now()
+        );
         if(avaliacoesExpiradas.isEmpty()){
             return;
         }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUso.java
@@ -20,7 +20,7 @@ public class ExpirarAvaliacaoCasoDeUso {
 
     @Transactional
     public void executar(){
-        List<Avaliacao> avaliacoesExpiradas = repositorio.buscarExpiradas(LocalDateTime.now());
+        List<Avaliacao> avaliacoesExpiradas = repositorio.buscarExpiradas(StatusAvaliacao.DISPONIVEL, LocalDateTime.now());
         if(avaliacoesExpiradas.isEmpty()){
             return;
         }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/RenotificarClienteCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/RenotificarClienteCasoDeUso.java
@@ -1,0 +1,49 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.TentativaNotificacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.AvaliacaoParaNotificar;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.porta.AvaliacaoNotificadorPorta;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class RenotificarClienteCasoDeUso {
+
+    private final AvaliacaoRepositorio repositorio;
+    private final AvaliacaoNotificadorPorta notificador;
+
+    @Transactional
+    public void executar(){
+    renotificarAvaliacao(TentativaNotificacao.PRIMEIRA_TENTATIVA, 3);
+    renotificarAvaliacao(TentativaNotificacao.SEGUNDA_TENTATIVA, 6);
+
+    }
+
+    private void renotificarAvaliacao(TentativaNotificacao tentativa, int diasParaNovaTentativa) {
+        List<Avaliacao> avaliacoes = repositorio.buscarPendentesDeRenotificacao(
+                StatusAvaliacao.DISPONIVEL,
+                tentativa,
+                LocalDateTime.now().minusDays(diasParaNovaTentativa)
+        );
+
+        avaliacoes.forEach(avaliacao -> {
+            try {
+                avaliacao.foiEnviadaAoCliente();
+                notificador.notificarCliente(new AvaliacaoParaNotificar(avaliacao.getId(), avaliacao.getClienteId(), avaliacao.getPedidoId()));
+            }
+            catch (Exception e) {
+                log.error("Erro ao notificar avaliacao id={}", avaliacao.getId(), e);
+            }
+            });
+        repositorio.salvarLista(avaliacoes);
+    }
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -18,9 +19,10 @@ import java.util.List;
 
 @Entity
 @Table(name = "avaliacoes")
+@ToString
 @NoArgsConstructor
 @Getter
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @AttributeOverrides({
         @AttributeOverride(name = "nota.valor", column = @Column(name = "nota_valor")),
         @AttributeOverride(name = "comentarioAvaliacao.valor", column = @Column(name = "comentario_valor"))

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
@@ -102,7 +102,7 @@ public class Avaliacao extends Avaliavel {
         }
     }
     public void expirarAvaliacao(){
-        if(LocalDateTime.now().isAfter(this.dataExpiracao)){
+        if(!LocalDateTime.now().isBefore(this.dataExpiracao)){
             mudarStatusAvaliacao(StatusAvaliacao.EXPIRADA);
             return;
         }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
@@ -102,7 +102,7 @@ public class Avaliacao extends Avaliavel {
         }
     }
     public void expirarAvaliacao(){
-        if(!LocalDateTime.now().isBefore(this.dataExpiracao)){
+        if(LocalDateTime.now().isAfter(this.dataExpiracao)){
             mudarStatusAvaliacao(StatusAvaliacao.EXPIRADA);
             return;
         }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
@@ -1,6 +1,5 @@
 package com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.ClassificacaoAvaliacao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.TentativaNotificacao;
@@ -22,7 +21,11 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 @EqualsAndHashCode
-public class Avaliacao {
+@AttributeOverrides({
+        @AttributeOverride(name = "nota.valor", column = @Column(name = "nota_valor")),
+        @AttributeOverride(name = "comentarioAvaliacao.valor", column = @Column(name = "comentario_valor"))
+})
+public class Avaliacao extends Avaliavel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,12 +34,6 @@ public class Avaliacao {
     private Long pedidoId;
     @NotNull
     private Long clienteId;
-    @Embedded
-    @AttributeOverride(name = "valor", column = @Column(name = "nota_valor"))
-    private NotaAvaliacao nota;
-    @Embedded
-    @AttributeOverride(name = "valor", column = @Column(name = "comentario_valor"))
-    private ComentarioAvaliacao comentarioAvaliacao;
     @Enumerated(EnumType.STRING)
     private StatusAvaliacao status;
     @Enumerated(EnumType.STRING)
@@ -44,9 +41,9 @@ public class Avaliacao {
     @Enumerated(EnumType.STRING)
     private TentativaNotificacao numeroNotificacaoCliente;
     @NotNull
-    LocalDateTime dataCriacao;
+    private LocalDateTime dataCriacao;
     @NotNull
-    LocalDateTime dataExpiracao;
+    private LocalDateTime dataExpiracao;
     @OneToMany(mappedBy = "avaliacao", cascade = CascadeType.ALL, orphanRemoval = true)
     List<AvaliacaoItem> itensAvaliados = new ArrayList<>();
 
@@ -74,7 +71,7 @@ public class Avaliacao {
         this.clienteId = clienteId;
     }
 
-    protected void mudarStatusAvaliacao(StatusAvaliacao status){
+    public void mudarStatusAvaliacao(StatusAvaliacao status){
         if (!this.status.podeTransicionarPara(status)) {
             throw new StatusAvaliacaoInvalidoExcecao(
                     "Transição inválida: " + this.status + " -> " + status
@@ -104,38 +101,18 @@ public class Avaliacao {
     }
     protected void expirarAvaliacao(){
         if(LocalDateTime.now().isAfter(this.dataExpiracao)) {
-            this.status = StatusAvaliacao.EXPIRADA;
+            mudarStatusAvaliacao(StatusAvaliacao.EXPIRADA);
             return;
         }
         throw new AvaliacaoNaoExpiradaExcecao("A data de expiração ainda não chegou para esta avaliação");
 
     }
     protected void concluirAvaliacao(NotaAvaliacao nota, ComentarioAvaliacao comentario){
-        validarSePodeTransicionarPara();
         vincularAvaliacao(nota, comentario);
         classificarAvaliacao(nota);
-        this.status = StatusAvaliacao.CONCLUIDA;
+        mudarStatusAvaliacao(StatusAvaliacao.CONCLUIDA);
     }
 
-    private void validarSePodeTransicionarPara(){
-        if(!this.status.podeTransicionarPara(StatusAvaliacao.CONCLUIDA)){
-            throw new StatusAvaliacaoInvalidoExcecao("Avaliação não pode ser concluída no status atual.");
-        }
-    }
-    private void vincularAvaliacao(NotaAvaliacao nota, ComentarioAvaliacao comentarioAvaliacao){
-        if(nota == null && comentarioAvaliacao != null){
-            throw new AvaliacaoInvalidaExcecao("Avaliação obrigatoriamente deve possuir uma Nota.");
-        }
-        //Voto em branco: aceita e não faz nada
-        if(nota == null){
-            this.nota = null;
-            this.comentarioAvaliacao = null;
-            return;
-        }
-        //Cenário de sucesso: preenche o que veio (usando ternário para o default)
-        this.nota = nota;
-        this.comentarioAvaliacao = (comentarioAvaliacao != null) ? comentarioAvaliacao : new ComentarioAvaliacao("Avaliação feita sem comentário");
-    }
     private void classificarAvaliacao(NotaAvaliacao nota){
         if(nota == null) {
             this.avaliacao = ClassificacaoAvaliacao.NAO_AVALIADO;

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliacao.java
@@ -101,8 +101,8 @@ public class Avaliacao extends Avaliavel {
             this.itensAvaliados.add(item);
         }
     }
-    protected void expirarAvaliacao(){
-        if(LocalDateTime.now().isAfter(this.dataExpiracao)) {
+    public void expirarAvaliacao(){
+        if(!LocalDateTime.now().isBefore(this.dataExpiracao)){
             mudarStatusAvaliacao(StatusAvaliacao.EXPIRADA);
             return;
         }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/AvaliacaoItem.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/AvaliacaoItem.java
@@ -1,10 +1,9 @@
 package com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.AvaliacaoInvalidaExcecao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.IdItemAvaliacaoVazioExcecao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.ItemAvaliadoVazioExcecao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.ComentarioAvaliacao;
-import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.IdItemAvaliacaoVazioExcecao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.NotaAvaliacao;
 import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
@@ -14,10 +13,14 @@ import lombok.Setter;
 
 @Entity
 @Table(name = "item_pedido_avaliado")
-@EqualsAndHashCode
 @NoArgsConstructor
 @Getter
-public class AvaliacaoItem {
+@EqualsAndHashCode
+@AttributeOverrides({
+        @AttributeOverride(name = "nota.valor", column = @Column(name = "item_nota_valor")),
+        @AttributeOverride(name = "comentarioAvaliacao.valor", column = @Column(name = "item_comentario_valor"))
+})
+public class AvaliacaoItem extends Avaliavel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,51 +28,30 @@ public class AvaliacaoItem {
     @ManyToOne
     @JoinColumn(name = "avaliacao_id")
     @Setter
-    @JsonIgnore //quando tiver dtos da pra remover
+    @JsonIgnore
     private Avaliacao avaliacao;
     private Long produtoId;
     private String nomeProdutoAvaliacao;
-    @Embedded
-    @AttributeOverride(name = "valor", column = @Column(name = "item_nota_valor"))
-    private NotaAvaliacao nota;
-    @Embedded
-    @AttributeOverride(name = "valor", column = @Column(name = "item_comentario_valor"))
-    private ComentarioAvaliacao comentarioAvaliacao;
 
-    public static AvaliacaoItem criar(Long produtoId,String nomeItemPedido, NotaAvaliacao notaAvaliacao, ComentarioAvaliacao comentarioAvaliacao) {
+    public static AvaliacaoItem criar(Long produtoId, String nomeItemPedido, NotaAvaliacao notaAvaliacao, ComentarioAvaliacao comentarioAvaliacao) {
         AvaliacaoItem avaliacaoItem = new AvaliacaoItem();
         avaliacaoItem.setProdutoId(produtoId);
         avaliacaoItem.setNomeProdutoAvaliacao(nomeItemPedido);
-        avaliacaoItem.nota = notaAvaliacao;
-        avaliacaoItem.comentarioAvaliacao = comentarioAvaliacao;
-        return  avaliacaoItem;
+        avaliacaoItem.vincularAvaliacao(notaAvaliacao, comentarioAvaliacao);
+        return avaliacaoItem;
     }
 
     private void setProdutoId(Long produtoId) {
-        if(produtoId == null) {
+        if (produtoId == null) {
             throw new IdItemAvaliacaoVazioExcecao("O id do produto avaliado não pode ser vazio");
         }
         this.produtoId = produtoId;
     }
+
     private void setNomeProdutoAvaliacao(String nomeProdutoAvaliacao) {
         if (nomeProdutoAvaliacao == null || nomeProdutoAvaliacao.isEmpty()) {
             throw new ItemAvaliadoVazioExcecao("Nome do pedido não pode ser vazio");
         }
         this.nomeProdutoAvaliacao = nomeProdutoAvaliacao;
-    }
-
-    protected void vincularAvaliacao(NotaAvaliacao nota, ComentarioAvaliacao comentarioAvaliacao){
-        if(nota == null && comentarioAvaliacao != null){
-            throw new AvaliacaoInvalidaExcecao("Avaliação obrigatoriamente deve possuir uma Nota.");
-        }
-        //Voto em branco: aceita e não faz nada
-        if(nota == null){
-            this.nota = null;
-            this.comentarioAvaliacao = null;
-            return;
-        }
-        //Cenário de sucesso: preenche o que veio (usando ternário para o default)
-        this.nota = nota;
-        this.comentarioAvaliacao = (comentarioAvaliacao != null) ? comentarioAvaliacao : new ComentarioAvaliacao("Avaliação feita sem comentário");
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliavel.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/Avaliavel.java
@@ -1,0 +1,31 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.excecao.AvaliacaoInvalidaExcecao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.ComentarioAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.NotaAvaliacao;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+public class Avaliavel {
+
+    @Embedded
+    private NotaAvaliacao nota;
+    @Embedded
+    private ComentarioAvaliacao comentarioAvaliacao;
+
+    protected void vincularAvaliacao(NotaAvaliacao nota, ComentarioAvaliacao comentarioAvaliacao) {
+        if (nota == null && comentarioAvaliacao != null) {
+            throw new AvaliacaoInvalidaExcecao("Avaliação obrigatoriamente deve possuir uma Nota.");
+        }
+        if (nota == null) {
+            this.nota = null;
+            this.comentarioAvaliacao = null;
+            return;
+        }
+        this.nota = nota;
+        this.comentarioAvaliacao = (comentarioAvaliacao != null) ? comentarioAvaliacao : new ComentarioAvaliacao("Avaliação feita sem comentário");
+    }
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/objeto_de_valor/AvaliacaoParaNotificar.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/objeto_de_valor/AvaliacaoParaNotificar.java
@@ -1,0 +1,5 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor;
+
+//isso aqui precisa pensar ainda em como fazer, pois precisa de dados completos para enviar a notificação
+public record AvaliacaoParaNotificar(Long avaliacaoId, Long clienteId, Long pedidoId) {
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/porta/AvaliacaoNotificadorPorta.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/porta/AvaliacaoNotificadorPorta.java
@@ -1,0 +1,9 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.dominio.porta;
+
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.AvaliacaoParaNotificar;
+
+//serviço de notificação deve implementar
+public interface AvaliacaoNotificadorPorta {
+    void notificarCliente(AvaliacaoParaNotificar avaliacao);
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/repositorio/AvaliacaoRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/repositorio/AvaliacaoRepositorio.java
@@ -1,6 +1,7 @@
 package com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio;
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,6 +14,7 @@ public interface AvaliacaoRepositorio {
     Optional<Avaliacao> buscarPorId(Long idAvaliacao);
     Optional<Avaliacao> buscarPorPedidoId(Long idPedido);
     List<Avaliacao> buscarTodos();
-    List<Avaliacao> buscarExpiradas(LocalDateTime horarioAgora);
+    List<Avaliacao> buscarExpiradas(StatusAvaliacao status, LocalDateTime horarioAgora);
+    List<Avaliacao> buscarTodasCriadasAte(StatusAvaliacao status, LocalDateTime horario);
 
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/repositorio/AvaliacaoRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/repositorio/AvaliacaoRepositorio.java
@@ -2,14 +2,17 @@ package com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio;
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface AvaliacaoRepositorio {
     Avaliacao salvar(Avaliacao avaliacao);
+    List<Avaliacao> salvarLista(List<Avaliacao> avaliacoes);
     Avaliacao atualizar(Avaliacao avaliacao);
     Optional<Avaliacao> buscarPorId(Long idAvaliacao);
     Optional<Avaliacao> buscarPorPedidoId(Long idPedido);
     List<Avaliacao> buscarTodos();
+    List<Avaliacao> buscarExpiradas(LocalDateTime horarioAgora);
 
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/repositorio/AvaliacaoRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/repositorio/AvaliacaoRepositorio.java
@@ -2,6 +2,7 @@ package com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio;
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.TentativaNotificacao;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,5 +17,6 @@ public interface AvaliacaoRepositorio {
     List<Avaliacao> buscarTodos();
     List<Avaliacao> buscarExpiradas(StatusAvaliacao status, LocalDateTime horarioAgora);
     List<Avaliacao> buscarTodasCriadasAte(StatusAvaliacao status, LocalDateTime horario);
+    List<Avaliacao> buscarPendentesDeRenotificacao(StatusAvaliacao status, TentativaNotificacao TentativaNotificacao, LocalDateTime horario);
 
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/adaptador/AvaliacaoJpaRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/adaptador/AvaliacaoJpaRepositorio.java
@@ -1,11 +1,13 @@
 package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.adaptador;
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
 import com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.persistencia.AvaliacaoJPA;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,11 +16,15 @@ import java.util.Optional;
 public class AvaliacaoJpaRepositorio implements AvaliacaoRepositorio {
     private final AvaliacaoJPA jpa;
 
-
     @Override
     public Avaliacao salvar(Avaliacao avaliacao){
         return jpa.save(avaliacao);
     }
+
+    @Override
+    public List<Avaliacao> salvarLista(List<Avaliacao> avaliacoes){
+        return jpa.saveAll(avaliacoes);
+    };
     @Override
     public Avaliacao atualizar(Avaliacao avaliacao){
         return jpa.save(avaliacao);
@@ -37,5 +43,10 @@ public class AvaliacaoJpaRepositorio implements AvaliacaoRepositorio {
     @Override
     public List<Avaliacao> buscarTodos(){
         return jpa.findAll();
+    }
+
+    @Override
+    public List<Avaliacao> buscarExpiradas(LocalDateTime horarioAgora){
+        return jpa.findByStatusAndDataExpiracaoBefore(StatusAvaliacao.DISPONIVEL, horarioAgora);
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/adaptador/AvaliacaoJpaRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/adaptador/AvaliacaoJpaRepositorio.java
@@ -46,7 +46,12 @@ public class AvaliacaoJpaRepositorio implements AvaliacaoRepositorio {
     }
 
     @Override
-    public List<Avaliacao> buscarExpiradas(LocalDateTime horarioAgora){
-        return jpa.findByStatusAndDataExpiracaoBefore(StatusAvaliacao.DISPONIVEL, horarioAgora);
+    public List<Avaliacao> buscarExpiradas(StatusAvaliacao status, LocalDateTime horarioAgora){
+        return jpa.findByStatusAndDataExpiracaoBefore(status, horarioAgora);
+    }
+
+    @Override
+    public List<Avaliacao> buscarTodasCriadasAte(StatusAvaliacao status, LocalDateTime horario){
+        return jpa.findByStatusAndDataCriacaoBefore(status, horario);
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/adaptador/AvaliacaoJpaRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/adaptador/AvaliacaoJpaRepositorio.java
@@ -2,6 +2,7 @@ package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.adapt
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.TentativaNotificacao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
 import com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.persistencia.AvaliacaoJPA;
 import lombok.RequiredArgsConstructor;
@@ -53,5 +54,10 @@ public class AvaliacaoJpaRepositorio implements AvaliacaoRepositorio {
     @Override
     public List<Avaliacao> buscarTodasCriadasAte(StatusAvaliacao status, LocalDateTime horario){
         return jpa.findByStatusAndDataCriacaoBefore(status, horario);
+    }
+
+    @Override
+    public List<Avaliacao> buscarPendentesDeRenotificacao(StatusAvaliacao status, TentativaNotificacao TentativaNotificacao, LocalDateTime horario){
+        return jpa.findByStatusAndNumeroNotificacaoClienteAndDataCriacaoBefore(status, TentativaNotificacao, horario);
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/persistencia/AvaliacaoJPA.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/persistencia/AvaliacaoJPA.java
@@ -11,4 +11,4 @@ import java.util.Optional;
 public interface AvaliacaoJPA extends JpaRepository<Avaliacao, Long> {
     Optional<Avaliacao>  findByPedidoId(Long idPedido);
     List<Avaliacao>  findByStatusAndDataExpiracaoBefore(StatusAvaliacao status, LocalDateTime dataExpiracao);
-}
+    List<Avaliacao> findByStatusAndDataCriacaoBefore(StatusAvaliacao status, LocalDateTime dataCriacao);}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/persistencia/AvaliacaoJPA.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/persistencia/AvaliacaoJPA.java
@@ -1,10 +1,14 @@
 package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.persistencia;
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface AvaliacaoJPA extends JpaRepository<Avaliacao, Long> {
     Optional<Avaliacao>  findByPedidoId(Long idPedido);
+    List<Avaliacao>  findByStatusAndDataExpiracaoBefore(StatusAvaliacao status, LocalDateTime dataExpiracao);
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/persistencia/AvaliacaoJPA.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/persistencia/AvaliacaoJPA.java
@@ -2,6 +2,7 @@ package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.persi
 
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
 import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.TentativaNotificacao;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -10,5 +11,8 @@ import java.util.Optional;
 
 public interface AvaliacaoJPA extends JpaRepository<Avaliacao, Long> {
     Optional<Avaliacao>  findByPedidoId(Long idPedido);
-    List<Avaliacao>  findByStatusAndDataExpiracaoBefore(StatusAvaliacao status, LocalDateTime dataExpiracao);
-    List<Avaliacao> findByStatusAndDataCriacaoBefore(StatusAvaliacao status, LocalDateTime dataCriacao);}
+    List<Avaliacao>findByStatusAndDataExpiracaoBefore(StatusAvaliacao status, LocalDateTime dataExpiracao);
+    List<Avaliacao>findByStatusAndDataCriacaoBefore(StatusAvaliacao status, LocalDateTime dataCriacao);
+    List<Avaliacao> findByStatusAndNumeroNotificacaoClienteAndDataCriacaoBefore(StatusAvaliacao statusAvaliacao, TentativaNotificacao TentativaNotificacao, LocalDateTime dataCriacao);
+}
+

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/DisponibilizaAvaliacaoCriadaScheduler.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/DisponibilizaAvaliacaoCriadaScheduler.java
@@ -1,0 +1,20 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.schuduler;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso.DisponibilizarAvaliacaoCasoDeUso;
+import lombok.AllArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class DisponibilizaAvaliacaoCriadaScheduler {
+
+    private final DisponibilizarAvaliacaoCasoDeUso casoDeUso;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void executar(){
+        casoDeUso.executar();
+    }
+
+
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/DisponibilizaAvaliacaoCriadaScheduler.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/DisponibilizaAvaliacaoCriadaScheduler.java
@@ -11,7 +11,7 @@ public class DisponibilizaAvaliacaoCriadaScheduler {
 
     private final DisponibilizarAvaliacaoCasoDeUso casoDeUso;
 
-    @Scheduled(fixedDelay = 60_000)
+    @Scheduled(fixedDelay = 60_000) //precisa ajustar o timer para um valor coerente com a regra.
     public void executar(){
         casoDeUso.executar();
     }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/ExpirarAvaliacoesScheduler.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/ExpirarAvaliacoesScheduler.java
@@ -1,0 +1,19 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.schuduler;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso.ExpirarAvaliacaoCasoDeUso;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ExpirarAvaliacoesScheduler {
+
+    private final ExpirarAvaliacaoCasoDeUso casoDeUso;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void executar(){
+        casoDeUso.executar();
+    }
+}
+

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/RenotificarAvaliacoesDisponiveisScheduler.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/RenotificarAvaliacoesDisponiveisScheduler.java
@@ -1,0 +1,19 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.schuduler;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso.RenotificarClienteCasoDeUso;
+import lombok.AllArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@AllArgsConstructor
+@Component
+public class RenotificarAvaliacoesDisponiveisScheduler {
+
+    private final RenotificarClienteCasoDeUso casoDeUso;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void executar(){
+        casoDeUso.executar();
+    }
+
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/casodeuso/AtualizarStatusPedidoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/casodeuso/AtualizarStatusPedidoCasoDeUso.java
@@ -7,7 +7,6 @@ import com.restaurante01.api_restaurante.compartilhado.dominio.enums.TipoEvento;
 import com.restaurante01.api_restaurante.modulos.pedido.api.dto.entrada.StatusPedidoDTO;
 import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.PedidoCriadoDTO;
 import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.mapeador.PedidoMapeador;
-import com.restaurante01.api_restaurante.modulos.pedido.dominio.enums.StatusPedido;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.evento.PedidoCanceladoEvento;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.evento.PedidoEntregueEvento;
@@ -44,15 +43,12 @@ public class AtualizarStatusPedidoCasoDeUso {
         Pedido pedido = pedidoRepository.buscarPorId(id)
                 .orElseThrow(() -> new PedidoNaoEncontradoExcecao("Pedido não localizado: " + id));
         pedido.mudarStatus(novoStatusDto.statusPedido());
-        pedidoRepository.salvar(pedido);
-        if (pedido.getStatusPedido() == StatusPedido.ENTREGUE) {
-            publicaEventosSeEntregue(pedido);
+        Pedido pedidoAtualizado = pedidoRepository.salvar(pedido);
+        switch (pedido.getStatusPedido()) {
+            case ENTREGUE -> publicaEventosSeEntregue(pedidoAtualizado);
+            case CANCELADO -> publicaEventosSeCancelado(pedidoAtualizado);
         }
-        if(pedido.getStatusPedido() == StatusPedido.CANCELADO){
-
-            publicaEventosSeCancelado(pedido);
-        }
-        return pedidoMapeador.mapearPedidoCriadoDto(pedido);
+        return pedidoMapeador.mapearPedidoCriadoDto(pedidoAtualizado);
     }
     private void publicaEventosSeEntregue(Pedido pedido) throws JsonProcessingException {
         List<ItemPedidoAvaliacaoPayload> itensParaAvaliacao = pedidoMapeador.mapearItemPedidoAvaliacaoPayload(pedido.getItens());

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/DisponibilizarAvaliacaoCasoDeUsoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/DisponibilizarAvaliacaoCasoDeUsoTest.java
@@ -1,0 +1,112 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.AvaliacaoBuilder;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.TentativaNotificacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.AvaliacaoParaNotificar;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.porta.AvaliacaoNotificadorPorta;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DisponibilizarAvaliacaoCasoDeUsoTest {
+
+    @Mock
+    private AvaliacaoRepositorio repositorio;
+
+    @Mock
+    private AvaliacaoNotificadorPorta notificadorPorta;
+
+    @InjectMocks
+    private DisponibilizarAvaliacaoCasoDeUso casoDeUso;
+
+    @Test
+    @DisplayName("Dado que nao ha avaliacoes PENDENTE antigas, Quando executar, Entao retorna sem salvar nem notificar")
+    void naoDeveFazerNadaSeListaVazia() {
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.PENDENTE), any(LocalDateTime.class)))
+                .thenReturn(Collections.emptyList());
+
+        casoDeUso.executar();
+
+        verify(notificadorPorta, never()).notificarCliente(any());
+        verify(repositorio, never()).salvarLista(any());
+    }
+
+    @Test
+    @DisplayName("Dado uma avaliacao PENDENTE criada ha mais de 1 hora, Quando executar, Entao deve mudar status para DISPONIVEL e notificar")
+    void deveDisponibilizarENotificarAvaliacao() {
+        Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
+
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.PENDENTE), any(LocalDateTime.class)))
+                .thenReturn(List.of(avaliacao));
+
+        casoDeUso.executar();
+
+        assertThat(avaliacao.getStatus()).isEqualTo(StatusAvaliacao.DISPONIVEL);
+        verify(notificadorPorta).notificarCliente(
+                new AvaliacaoParaNotificar(avaliacao.getId(), avaliacao.getClienteId(), avaliacao.getPedidoId()));
+        verify(repositorio).salvarLista(List.of(avaliacao));
+    }
+
+    @Test
+    @DisplayName("Dado uma avaliacao PENDENTE, Quando disponibilizada, Entao deve registrar como PRIMEIRA_TENTATIVA de notificacao")
+    void deveRegistrarPrimeiraNotificacaoAoDisponibilizar() {
+        Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
+
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.PENDENTE), any(LocalDateTime.class)))
+                .thenReturn(List.of(avaliacao));
+
+        casoDeUso.executar();
+
+        assertThat(avaliacao.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.PRIMEIRA_TENTATIVA);
+    }
+
+    @Test
+    @DisplayName("Dado que o notificador falha, Quando executar, Entao deve absorver o erro e ainda salvar a lista")
+    void deveContinuarMesmoComErroDeNotificacao() {
+        Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
+
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.PENDENTE), any(LocalDateTime.class)))
+                .thenReturn(List.of(avaliacao));
+        doThrow(new RuntimeException("Falha de notificacao")).when(notificadorPorta).notificarCliente(any());
+
+        casoDeUso.executar();
+
+        assertThat(avaliacao.getStatus()).isEqualTo(StatusAvaliacao.DISPONIVEL);
+        assertThat(avaliacao.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.PRIMEIRA_TENTATIVA);
+        verify(repositorio).salvarLista(List.of(avaliacao));
+    }
+
+    @Test
+    @DisplayName("Dado qualquer cenario, Quando executar, Entao deve buscar avaliacoes criadas ha mais de 1 hora")
+    void deveBuscarComLimiteDeUmaHora() {
+        ArgumentCaptor<LocalDateTime> horarioCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.PENDENTE), any(LocalDateTime.class)))
+                .thenReturn(Collections.emptyList());
+
+        LocalDateTime antes = LocalDateTime.now();
+        casoDeUso.executar();
+        LocalDateTime depois = LocalDateTime.now();
+
+        verify(repositorio).buscarTodasCriadasAte(eq(StatusAvaliacao.PENDENTE), horarioCaptor.capture());
+        assertThat(horarioCaptor.getValue()).isBetween(
+                antes.minusHours(1),
+                depois.minusHours(1));
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUsoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUsoTest.java
@@ -38,7 +38,7 @@ class ExpirarAvaliacaoCasoDeUsoTest {
     @Test
     @DisplayName("Dado que nao ha avaliacoes expiradas, Quando executar, Entao nao deve salvar nada")
     void naoDeveSalvarSeListaVazia() {
-        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
                 .thenReturn(Collections.emptyList());
 
         casoDeUso.executar();
@@ -47,13 +47,13 @@ class ExpirarAvaliacaoCasoDeUsoTest {
     }
 
     @Test
-    @DisplayName("Dado uma avaliacao DISPONIVEL com data vencida, Quando executar, Entao deve atualizar para EXPIRADA e salvar")
+    @DisplayName("Dado uma avaliacao DISPONIVEL com dataExpiracao no passado, Quando executar, Entao deve atualizar para EXPIRADA e salvar")
     void deveExpirarUmaAvaliacao() {
         Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
         ReflectionTestUtils.setField(avaliacao, "status", StatusAvaliacao.DISPONIVEL);
         ReflectionTestUtils.setField(avaliacao, "dataExpiracao", LocalDateTime.now().minusDays(1));
 
-        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
                 .thenReturn(List.of(avaliacao));
 
         casoDeUso.executar();
@@ -63,7 +63,7 @@ class ExpirarAvaliacaoCasoDeUsoTest {
     }
 
     @Test
-    @DisplayName("Dado multiplas avaliacoes DISPONIVEL com data vencida, Quando executar, Entao deve atualizar todas para EXPIRADA")
+    @DisplayName("Dado multiplas avaliacoes DISPONIVEL com dataExpiracao no passado, Quando executar, Entao deve atualizar todas para EXPIRADA")
     void deveExpirarMultiplasAvaliacoes() {
         Avaliacao av1 = AvaliacaoBuilder.umaAvaliacao().construir();
         Avaliacao av2 = AvaliacaoBuilder.umaAvaliacao().construir();
@@ -72,7 +72,7 @@ class ExpirarAvaliacaoCasoDeUsoTest {
         ReflectionTestUtils.setField(av1, "dataExpiracao", LocalDateTime.now().minusDays(1));
         ReflectionTestUtils.setField(av2, "dataExpiracao", LocalDateTime.now().minusDays(1));
 
-        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
                 .thenReturn(List.of(av1, av2));
 
         casoDeUso.executar();
@@ -84,19 +84,17 @@ class ExpirarAvaliacaoCasoDeUsoTest {
     }
 
     @Test
-    @DisplayName("Dado qualquer cenario, Quando executar, Entao deve buscar com janela de 7 dias atras")
-    void deveBuscarComJanelaDe7Dias() {
+    @DisplayName("Dado qualquer cenario, Quando executar, Entao deve buscar com horario proximo ao atual")
+    void deveBuscarComHorarioAtual() {
         ArgumentCaptor<LocalDateTime> horarioCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
-        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
                 .thenReturn(Collections.emptyList());
 
         LocalDateTime antes = LocalDateTime.now();
         casoDeUso.executar();
         LocalDateTime depois = LocalDateTime.now();
 
-        verify(repositorio).buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), horarioCaptor.capture());
-        assertThat(horarioCaptor.getValue()).isBetween(
-                antes.minusDays(7),
-                depois.minusDays(7));
+        verify(repositorio).buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), horarioCaptor.capture());
+        assertThat(horarioCaptor.getValue()).isBetween(antes, depois);
     }
 }

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUsoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUsoTest.java
@@ -1,0 +1,97 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.AvaliacaoBuilder;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ExpirarAvaliacaoCasoDeUsoTest {
+
+    @Mock
+    private AvaliacaoRepositorio repositorio;
+
+    @InjectMocks
+    private ExpirarAvaliacaoCasoDeUso casoDeUso;
+
+    @Captor
+    private ArgumentCaptor<List<Avaliacao>> listaCaptor;
+
+    @Test
+    @DisplayName("Dado que nao ha avaliacoes expiradas, Quando executar, Entao nao deve salvar nada")
+    void naoDeveSalvarSeListaVazia() {
+        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+                .thenReturn(Collections.emptyList());
+
+        casoDeUso.executar();
+
+        verify(repositorio, never()).salvarLista(any());
+    }
+
+    @Test
+    @DisplayName("Dado uma avaliacao DISPONIVEL expirada, Quando executar, Entao deve atualizar para EXPIRADA e salvar")
+    void deveExpirarUmaAvaliacao() {
+        Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
+        ReflectionTestUtils.setField(avaliacao, "status", StatusAvaliacao.DISPONIVEL);
+
+        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+                .thenReturn(List.of(avaliacao));
+
+        casoDeUso.executar();
+
+        assertThat(avaliacao.getStatus()).isEqualTo(StatusAvaliacao.EXPIRADA);
+        verify(repositorio).salvarLista(List.of(avaliacao));
+    }
+
+    @Test
+    @DisplayName("Dado multiplas avaliacoes DISPONIVEL expiradas, Quando executar, Entao deve atualizar todas para EXPIRADA")
+    void deveExpirarMultiplasAvaliacoes() {
+        Avaliacao av1 = AvaliacaoBuilder.umaAvaliacao().construir();
+        Avaliacao av2 = AvaliacaoBuilder.umaAvaliacao().construir();
+        ReflectionTestUtils.setField(av1, "status", StatusAvaliacao.DISPONIVEL);
+        ReflectionTestUtils.setField(av2, "status", StatusAvaliacao.DISPONIVEL);
+
+        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+                .thenReturn(List.of(av1, av2));
+
+        casoDeUso.executar();
+
+        assertThat(av1.getStatus()).isEqualTo(StatusAvaliacao.EXPIRADA);
+        assertThat(av2.getStatus()).isEqualTo(StatusAvaliacao.EXPIRADA);
+        verify(repositorio).salvarLista(listaCaptor.capture());
+        assertThat(listaCaptor.getValue()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Dado qualquer cenario, Quando executar, Entao deve buscar com horario proximo ao atual")
+    void deveBuscarComHorarioAtual() {
+        ArgumentCaptor<LocalDateTime> horarioCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+                .thenReturn(Collections.emptyList());
+
+        LocalDateTime antes = LocalDateTime.now();
+        casoDeUso.executar();
+        LocalDateTime depois = LocalDateTime.now();
+
+        verify(repositorio).buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), horarioCaptor.capture());
+        assertThat(horarioCaptor.getValue()).isBetween(antes, depois);
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUsoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/ExpirarAvaliacaoCasoDeUsoTest.java
@@ -38,7 +38,7 @@ class ExpirarAvaliacaoCasoDeUsoTest {
     @Test
     @DisplayName("Dado que nao ha avaliacoes expiradas, Quando executar, Entao nao deve salvar nada")
     void naoDeveSalvarSeListaVazia() {
-        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
                 .thenReturn(Collections.emptyList());
 
         casoDeUso.executar();
@@ -47,12 +47,13 @@ class ExpirarAvaliacaoCasoDeUsoTest {
     }
 
     @Test
-    @DisplayName("Dado uma avaliacao DISPONIVEL expirada, Quando executar, Entao deve atualizar para EXPIRADA e salvar")
+    @DisplayName("Dado uma avaliacao DISPONIVEL com data vencida, Quando executar, Entao deve atualizar para EXPIRADA e salvar")
     void deveExpirarUmaAvaliacao() {
         Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
         ReflectionTestUtils.setField(avaliacao, "status", StatusAvaliacao.DISPONIVEL);
+        ReflectionTestUtils.setField(avaliacao, "dataExpiracao", LocalDateTime.now().minusDays(1));
 
-        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
                 .thenReturn(List.of(avaliacao));
 
         casoDeUso.executar();
@@ -62,14 +63,16 @@ class ExpirarAvaliacaoCasoDeUsoTest {
     }
 
     @Test
-    @DisplayName("Dado multiplas avaliacoes DISPONIVEL expiradas, Quando executar, Entao deve atualizar todas para EXPIRADA")
+    @DisplayName("Dado multiplas avaliacoes DISPONIVEL com data vencida, Quando executar, Entao deve atualizar todas para EXPIRADA")
     void deveExpirarMultiplasAvaliacoes() {
         Avaliacao av1 = AvaliacaoBuilder.umaAvaliacao().construir();
         Avaliacao av2 = AvaliacaoBuilder.umaAvaliacao().construir();
         ReflectionTestUtils.setField(av1, "status", StatusAvaliacao.DISPONIVEL);
         ReflectionTestUtils.setField(av2, "status", StatusAvaliacao.DISPONIVEL);
+        ReflectionTestUtils.setField(av1, "dataExpiracao", LocalDateTime.now().minusDays(1));
+        ReflectionTestUtils.setField(av2, "dataExpiracao", LocalDateTime.now().minusDays(1));
 
-        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
                 .thenReturn(List.of(av1, av2));
 
         casoDeUso.executar();
@@ -81,17 +84,19 @@ class ExpirarAvaliacaoCasoDeUsoTest {
     }
 
     @Test
-    @DisplayName("Dado qualquer cenario, Quando executar, Entao deve buscar com horario proximo ao atual")
-    void deveBuscarComHorarioAtual() {
+    @DisplayName("Dado qualquer cenario, Quando executar, Entao deve buscar com janela de 7 dias atras")
+    void deveBuscarComJanelaDe7Dias() {
         ArgumentCaptor<LocalDateTime> horarioCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
-        when(repositorio.buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
+        when(repositorio.buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), any(LocalDateTime.class)))
                 .thenReturn(Collections.emptyList());
 
         LocalDateTime antes = LocalDateTime.now();
         casoDeUso.executar();
         LocalDateTime depois = LocalDateTime.now();
 
-        verify(repositorio).buscarExpiradas(eq(StatusAvaliacao.DISPONIVEL), horarioCaptor.capture());
-        assertThat(horarioCaptor.getValue()).isBetween(antes, depois);
+        verify(repositorio).buscarTodasCriadasAte(eq(StatusAvaliacao.DISPONIVEL), horarioCaptor.capture());
+        assertThat(horarioCaptor.getValue()).isBetween(
+                antes.minusDays(7),
+                depois.minusDays(7));
     }
 }

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/RenotificarClienteCasoDeUsoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/aplicacao/casodeuso/RenotificarClienteCasoDeUsoTest.java
@@ -1,0 +1,184 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.Avaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.entidade.AvaliacaoBuilder;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.StatusAvaliacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.enums.TentativaNotificacao;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.objeto_de_valor.AvaliacaoParaNotificar;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.porta.AvaliacaoNotificadorPorta;
+import com.restaurante01.api_restaurante.modulos.avaliacao.dominio.repositorio.AvaliacaoRepositorio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RenotificarClienteCasoDeUsoTest {
+
+    @Mock
+    private AvaliacaoRepositorio repositorio;
+
+    @Mock
+    private AvaliacaoNotificadorPorta notificador;
+
+    @InjectMocks
+    private RenotificarClienteCasoDeUso casoDeUso;
+
+    private Avaliacao disponivel() {
+        Avaliacao av = AvaliacaoBuilder.umaAvaliacao().construir();
+        ReflectionTestUtils.setField(av, "status", StatusAvaliacao.DISPONIVEL);
+        return av;
+    }
+
+    private void semPendentes() {
+        when(repositorio.buscarPendentesDeRenotificacao(any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+    }
+
+    @Test
+    @DisplayName("Dado que nao ha avaliacoes pendentes, Quando executar, Entao nao deve notificar nenhum cliente")
+    void naoDeveNotificarSemAvaliacoesPendentes() {
+        semPendentes();
+
+        casoDeUso.executar();
+
+        verify(notificador, never()).notificarCliente(any());
+    }
+
+    @Test
+    @DisplayName("Dado avaliacao com PRIMEIRA_TENTATIVA ha mais de 3 dias, Quando executar, Entao deve notificar e avançar para SEGUNDA_TENTATIVA")
+    void deveRenotificarAvialiacaoNaPrimeiraTentativa() {
+        Avaliacao av = disponivel();
+        av.foiEnviadaAoCliente(); // → PRIMEIRA_TENTATIVA
+
+        when(repositorio.buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL), eq(TentativaNotificacao.PRIMEIRA_TENTATIVA), any()))
+                .thenReturn(List.of(av));
+        when(repositorio.buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL), eq(TentativaNotificacao.SEGUNDA_TENTATIVA), any()))
+                .thenReturn(Collections.emptyList());
+
+        casoDeUso.executar();
+
+        assertThat(av.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.SEGUNDA_TENTATIVA);
+        verify(notificador).notificarCliente(
+                new AvaliacaoParaNotificar(av.getId(), av.getClienteId(), av.getPedidoId()));
+    }
+
+    @Test
+    @DisplayName("Dado avaliacao com SEGUNDA_TENTATIVA ha mais de 6 dias, Quando executar, Entao deve notificar e avançar para TERCEIRA_TENTATIVA")
+    void deveRenotificarAvaliacaoNaSegundaTentativa() {
+        Avaliacao av = disponivel();
+        av.foiEnviadaAoCliente(); // → PRIMEIRA_TENTATIVA
+        av.foiEnviadaAoCliente(); // → SEGUNDA_TENTATIVA
+
+        when(repositorio.buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL), eq(TentativaNotificacao.PRIMEIRA_TENTATIVA), any()))
+                .thenReturn(Collections.emptyList());
+        when(repositorio.buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL), eq(TentativaNotificacao.SEGUNDA_TENTATIVA), any()))
+                .thenReturn(List.of(av));
+
+        casoDeUso.executar();
+
+        assertThat(av.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.TERCEIRA_TENTATIVA);
+        verify(notificador).notificarCliente(
+                new AvaliacaoParaNotificar(av.getId(), av.getClienteId(), av.getPedidoId()));
+    }
+
+    @Test
+    @DisplayName("Dado ambos os grupos com pendencias, Quando executar, Entao deve processar as duas regras na mesma execucao")
+    void deveProcessarAmbasAsRegrasPorExecucao() {
+        Avaliacao avPrimeira = disponivel();
+        avPrimeira.foiEnviadaAoCliente(); // → PRIMEIRA_TENTATIVA
+
+        Avaliacao avSegunda = disponivel();
+        avSegunda.foiEnviadaAoCliente(); // → PRIMEIRA_TENTATIVA
+        avSegunda.foiEnviadaAoCliente(); // → SEGUNDA_TENTATIVA
+
+        when(repositorio.buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL), eq(TentativaNotificacao.PRIMEIRA_TENTATIVA), any()))
+                .thenReturn(List.of(avPrimeira));
+        when(repositorio.buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL), eq(TentativaNotificacao.SEGUNDA_TENTATIVA), any()))
+                .thenReturn(List.of(avSegunda));
+
+        casoDeUso.executar();
+
+        assertThat(avPrimeira.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.SEGUNDA_TENTATIVA);
+        assertThat(avSegunda.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.TERCEIRA_TENTATIVA);
+        verify(notificador, times(2)).notificarCliente(any());
+    }
+
+    @Test
+    @DisplayName("Dado que o notificador falha, Quando executar, Entao deve absorver o erro e ainda salvar a lista")
+    void deveContinuarEPersistirMesmoComErroDeNotificacao() {
+        Avaliacao av = disponivel();
+        av.foiEnviadaAoCliente(); // → PRIMEIRA_TENTATIVA
+
+        when(repositorio.buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL), eq(TentativaNotificacao.PRIMEIRA_TENTATIVA), any()))
+                .thenReturn(List.of(av));
+        when(repositorio.buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL), eq(TentativaNotificacao.SEGUNDA_TENTATIVA), any()))
+                .thenReturn(Collections.emptyList());
+        doThrow(new RuntimeException("Falha de notificacao")).when(notificador).notificarCliente(any());
+
+        casoDeUso.executar();
+
+        // foiEnviadaAoCliente foi chamado antes do notificador, então a tentativa avançou
+        assertThat(av.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.SEGUNDA_TENTATIVA);
+        verify(repositorio, atLeastOnce()).salvarLista(any());
+    }
+
+    @Test
+    @DisplayName("Dado qualquer cenario, Quando executar, Entao deve buscar PRIMEIRA_TENTATIVA com janela de 3 dias")
+    void deveBuscarPrimeiraTentativaComJanelaDe3Dias() {
+        ArgumentCaptor<LocalDateTime> horarioCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        semPendentes();
+
+        LocalDateTime antes = LocalDateTime.now();
+        casoDeUso.executar();
+        LocalDateTime depois = LocalDateTime.now();
+
+        verify(repositorio).buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL),
+                eq(TentativaNotificacao.PRIMEIRA_TENTATIVA),
+                horarioCaptor.capture());
+        assertThat(horarioCaptor.getValue()).isBetween(
+                antes.minusDays(3),
+                depois.minusDays(3));
+    }
+
+    @Test
+    @DisplayName("Dado qualquer cenario, Quando executar, Entao deve buscar SEGUNDA_TENTATIVA com janela de 6 dias")
+    void deveBuscarSegundaTentativaComJanelaDe6Dias() {
+        ArgumentCaptor<LocalDateTime> horarioCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        semPendentes();
+
+        LocalDateTime antes = LocalDateTime.now();
+        casoDeUso.executar();
+        LocalDateTime depois = LocalDateTime.now();
+
+        verify(repositorio).buscarPendentesDeRenotificacao(
+                eq(StatusAvaliacao.DISPONIVEL),
+                eq(TentativaNotificacao.SEGUNDA_TENTATIVA),
+                horarioCaptor.capture());
+        assertThat(horarioCaptor.getValue()).isBetween(
+                antes.minusDays(6),
+                depois.minusDays(6));
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/AvaliacaoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/AvaliacaoTest.java
@@ -170,4 +170,27 @@ class AvaliacaoTest {
 
         assertThat(avaliacao.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.PRIMEIRA_TENTATIVA);
     }
+
+    @Test
+    @DisplayName("Dado uma avaliação com PRIMEIRA_TENTATIVA, Quando notificada novamente, Então avança para SEGUNDA_TENTATIVA")
+    void deveAvancarParaSegundaNotificacao() {
+        Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
+        avaliacao.foiEnviadaAoCliente();
+
+        avaliacao.foiEnviadaAoCliente();
+
+        assertThat(avaliacao.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.SEGUNDA_TENTATIVA);
+    }
+
+    @Test
+    @DisplayName("Dado uma avaliação com SEGUNDA_TENTATIVA, Quando notificada novamente, Então avança para TERCEIRA_TENTATIVA")
+    void deveAvancarParaTerceiraNotificacao() {
+        Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
+        avaliacao.foiEnviadaAoCliente();
+        avaliacao.foiEnviadaAoCliente();
+
+        avaliacao.foiEnviadaAoCliente();
+
+        assertThat(avaliacao.getNumeroNotificacaoCliente()).isEqualTo(TentativaNotificacao.TERCEIRA_TENTATIVA);
+    }
 }

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/AvaliacaoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/dominio/entidade/AvaliacaoTest.java
@@ -149,6 +149,7 @@ class AvaliacaoTest {
     @DisplayName("Dado uma avaliação com data vencida, Quando pedir para expirar, Então altera status para EXPIRADA")
     void deveExpirarAvaliacaoVencida() {
         Avaliacao avaliacao = AvaliacaoBuilder.umaAvaliacao().construir();
+        ReflectionTestUtils.setField(avaliacao, "status", StatusAvaliacao.DISPONIVEL);
         ReflectionTestUtils.setField(avaliacao, "dataExpiracao", LocalDateTime.now().minusDays(1));
 
         avaliacao.expirarAvaliacao();

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/DisponibilizaAvaliacaoCriadaSchedulerTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/DisponibilizaAvaliacaoCriadaSchedulerTest.java
@@ -1,0 +1,38 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.schuduler;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso.DisponibilizarAvaliacaoCasoDeUso;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DisponibilizaAvaliacaoCriadaSchedulerTest {
+
+    @Mock
+    private DisponibilizarAvaliacaoCasoDeUso casoDeUso;
+
+    @InjectMocks
+    private DisponibilizaAvaliacaoCriadaScheduler scheduler;
+
+    @Test
+    @DisplayName("Quando o scheduler disparar, Entao deve delegar ao caso de uso")
+    void deveDelegarAoCasoDeUso() {
+        scheduler.executar();
+
+        verify(casoDeUso).executar();
+    }
+
+    @Test
+    @DisplayName("Quando o scheduler disparar, Entao nao deve chamar nada alem do caso de uso")
+    void naoDeveExecutarNadaAlemDoCasoDeUso() {
+        scheduler.executar();
+
+        verify(casoDeUso).executar();
+        verifyNoMoreInteractions(casoDeUso);
+    }
+}

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/RenotificarAvaliacoesDisponiveisSchedulerTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/avaliacao/infraestrutura/schuduler/RenotificarAvaliacoesDisponiveisSchedulerTest.java
@@ -1,0 +1,38 @@
+package com.restaurante01.api_restaurante.modulos.avaliacao.infraestrutura.schuduler;
+
+import com.restaurante01.api_restaurante.modulos.avaliacao.aplicacao.casodeuso.RenotificarClienteCasoDeUso;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RenotificarAvaliacoesDisponiveisSchedulerTest {
+
+    @Mock
+    private RenotificarClienteCasoDeUso casoDeUso;
+
+    @InjectMocks
+    private RenotificarAvaliacoesDisponiveisScheduler scheduler;
+
+    @Test
+    @DisplayName("Quando o scheduler disparar, Entao deve delegar ao caso de uso")
+    void deveDelegarAoCasoDeUso() {
+        scheduler.executar();
+
+        verify(casoDeUso).executar();
+    }
+
+    @Test
+    @DisplayName("Quando o scheduler disparar, Entao nao deve executar nada alem do caso de uso")
+    void naoDeveExecutarNadaAlemDoCasoDeUso() {
+        scheduler.executar();
+
+        verify(casoDeUso).executar();
+        verifyNoMoreInteractions(casoDeUso);
+    }
+}


### PR DESCRIPTION
## Resumo

- **RA-7/RA-32**: Implementa o ciclo de disponibilização de avaliação com `DisponibilizarAvaliacaoCasoDeUso` e `DisponibilizaAvaliacaoCriadaScheduler`, incluindo notificação ao cliente via `AvaliacaoNotificadorPorta`
- **RA-22**: Implementa `ExpirarAvaliacaoCasoDeUso` e `ExpirarAvaliacoesScheduler` para expirar avaliações com `dataExpiracao` atingida
- **RA-27**: Implementa `RenotificarClienteCasoDeUso` e `RenotificarAvaliacoesDisponiveisScheduler` para reenviar notificações de avaliações disponíveis ainda não respondidas
- Adiciona entidade `Avaliavel`, objeto de valor `AvaliacaoParaNotificar` e query `buscarPendentesDeRenotificacao` no repositório JPA
- Atualiza `DatabaseSeeder` com dados para testes locais

## Plano de testes

- [x] Testes unitários: `DisponibilizarAvaliacaoCasoDeUsoTest`, `ExpirarAvaliacaoCasoDeUsoTest`, `RenotificarClienteCasoDeUsoTest`
- [x] Testes unitários dos schedulers: `DisponibilizaAvaliacaoCriadaSchedulerTest`, `RenotificarAvaliacoesDisponiveisSchedulerTest`
- [x] Testes unitários da entidade: `AvaliacaoTest`
- [x] Subir a aplicação localmente e verificar os schedulers disparando nos intervalos configurados
- [x] Validar fluxo completo: criação do pedido → disponibilização da avaliação → expiração → renotificação