### PR TITLE
RA-61 RA-62: Teste de integração OutboxDespachante e restauração de eventos de pedido

### DIFF
--- a/src/test/java/com/restaurante01/api_restaurante/compartilhado/infraestrutura/scheduler/OutboxDespachanteIntegrationTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/compartilhado/infraestrutura/scheduler/OutboxDespachanteIntegrationTest.java
@@ -1,0 +1,110 @@
+package com.restaurante01.api_restaurante.compartilhado.infraestrutura.scheduler;
+
+import com.restaurante01.api_restaurante.compartilhado.aplicacao.OutboxEventoHandler;
+import com.restaurante01.api_restaurante.compartilhado.dominio.entidade.OutboxEvento;
+import com.restaurante01.api_restaurante.compartilhado.dominio.enums.Agregado;
+import com.restaurante01.api_restaurante.compartilhado.dominio.enums.GatilhoEvento;
+import com.restaurante01.api_restaurante.compartilhado.dominio.enums.TipoEvento;
+import com.restaurante01.api_restaurante.compartilhado.dominio.repositorio.OutboxRepositorio;
+import com.restaurante01.api_restaurante.compartilhado.infraestrutura.persistencia.OutboxJpaAdaptador;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({OutboxJpaAdaptador.class, OutboxDespachante.class})
+class OutboxDespachanteIntegrationTest {
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        CapturadorDeOrdem capturadorDeOrdem() {
+            return new CapturadorDeOrdem();
+        }
+    }
+
+    static class CapturadorDeOrdem implements OutboxEventoHandler {
+
+        private final List<Long> idsProcessados = new ArrayList<>();
+
+        @Override
+        public TipoEvento tipoEvento() {
+            return TipoEvento.COMPUTAR_PONTUACAO_FIDELIDADE;
+        }
+
+        @Override
+        public void processar(OutboxEvento evento) {
+            idsProcessados.add(evento.getId());
+        }
+
+        public List<Long> idsProcessados() {
+            return idsProcessados;
+        }
+    }
+
+    @Autowired
+    private OutboxRepositorio outboxRepositorio;
+
+    @Autowired
+    private OutboxDespachante outboxDespachante;
+
+    @Autowired
+    private CapturadorDeOrdem capturador;
+
+    @BeforeEach
+    void limpar() {
+        capturador.idsProcessados().clear();
+    }
+
+    @Test
+    @DisplayName("reprocessarPendentes deve processar eventos do mais antigo para o mais recente baseado em criadoEm")
+    void reprocessarPendentes_deveProcessarDoMaisAntigoParaOMaisRecente() throws Exception {
+        LocalDateTime agora = LocalDateTime.now();
+
+        // Inserção deliberadamente fora de ordem cronológica
+        OutboxEvento eventoMaisRecente   = criarComData(Agregado.PEDIDO, 1L, agora);
+        OutboxEvento eventoMaisAntigo    = criarComData(Agregado.PEDIDO, 2L, agora.minusHours(3));
+        OutboxEvento eventoIntermediario = criarComData(Agregado.PEDIDO, 3L, agora.minusHours(1));
+
+        outboxRepositorio.salvar(eventoMaisRecente);
+        outboxRepositorio.salvar(eventoMaisAntigo);
+        outboxRepositorio.salvar(eventoIntermediario);
+
+        outboxDespachante.reprocessarPendentes();
+
+        assertThat(capturador.idsProcessados())
+                .as("eventos devem ser processados do mais antigo (criadoEm menor) para o mais recente")
+                .hasSize(3)
+                .containsExactly(
+                        eventoMaisAntigo.getId(),
+                        eventoIntermediario.getId(),
+                        eventoMaisRecente.getId()
+                );
+    }
+
+    private OutboxEvento criarComData(Agregado agregado, Long agregadoId, LocalDateTime criadoEm) throws Exception {
+        OutboxEvento evento = OutboxEvento.criar(
+                agregado,
+                agregadoId,
+                GatilhoEvento.PEDIDO_ENTREGUE,
+                TipoEvento.COMPUTAR_PONTUACAO_FIDELIDADE,
+                "{}"
+        );
+        Field field = OutboxEvento.class.getDeclaredField("criadoEm");
+        field.setAccessible(true);
+        field.set(evento, criadoEm);
+        return evento;
+    }
+}


### PR DESCRIPTION
## Resumo

- Cria `OutboxDespachanteIntegrationTest` com `@DataJpaTest` e H2 em memória validando que `reprocessarPendentes()` processa eventos na ordem cronológica correta (do mais antigo para o mais recente), usando `PriorityQueue` baseada no campo `criadoEm`
- Restaura publicação de `PedidoCriadoEvento` em `CriarNovoPedidoCasoDeUso`
- Restaura publicação de `PedidoEntregueEvento` em `AtualizarStatusPedidoCasoDeUso`

## Tickets

- [RA-61](https://brunofragadev.atlassian.net/browse/RA-61) — Teste de integração OutboxDespachante
- [RA-62](https://brunofragadev.atlassian.net/browse/RA-62) — Restaurar publicação de eventos

## Plano de teste

- [ ] Rodar `./mvnw test -Dtest=OutboxDespachanteIntegrationTest` e verificar `BUILD SUCCESS`
- [ ] Confirmar que 3 eventos com timestamps distintos são processados na ordem: mais antigo → intermediário → mais recente

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RA-61]: https://brunofragadev.atlassian.net/browse/RA-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RA-62]: https://brunofragadev.atlassian.net/browse/RA-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ