### PR TITLE
RA-63: Dashboard Kanban em tempo real com pedidos ordenados por status via WebSocket

### DIFF
--- a/src/main/java/com/restaurante01/api_restaurante/compartilhado/dominio/entidade/OutboxEvento.java
+++ b/src/main/java/com/restaurante01/api_restaurante/compartilhado/dominio/entidade/OutboxEvento.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class OutboxEvento {
+public class OutboxEvento implements Comparable<OutboxEvento> {
 
     private static final int MAX_TENTATIVAS = 3;
 
@@ -99,5 +99,14 @@ public class OutboxEvento {
 
     public boolean esgotouTentativas() {
         return this.tentativas >= MAX_TENTATIVAS;
+    }
+
+    @Override
+    public int compareTo(OutboxEvento outroEvento) {
+        int resultado = this.criadoEm.compareTo(outroEvento.criadoEm);
+        if (resultado == 0) {
+            return Long.compare(this.id, outroEvento.id);
+        }
+        return resultado;
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/compartilhado/infraestrutura/persistencia/OutboxJPA.java
+++ b/src/main/java/com/restaurante01/api_restaurante/compartilhado/infraestrutura/persistencia/OutboxJPA.java
@@ -11,6 +11,6 @@ import java.util.Optional;
 
 public interface OutboxJPA extends JpaRepository<OutboxEvento, Long>{
     Optional<OutboxEvento> findByAgregadoTipoAndAgregadoIdAndTipo(Agregado agregadoTipo, Long agregadoId, TipoEvento tipoEvento);
-    List<OutboxEvento> findByStatus(StatusOutbox status);
+    List<OutboxEvento> findByStatusOrderByCriadoEmAsc(StatusOutbox status);
 }
 

--- a/src/main/java/com/restaurante01/api_restaurante/compartilhado/infraestrutura/persistencia/OutboxJpaAdaptador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/compartilhado/infraestrutura/persistencia/OutboxJpaAdaptador.java
@@ -31,7 +31,7 @@ public class OutboxJpaAdaptador implements OutboxRepositorio {
 
     @Override
     public List<OutboxEvento> buscarPendentes(){
-        return jpa.findByStatus(StatusOutbox.PENDENTE);
+        return jpa.findByStatusOrderByCriadoEmAsc(StatusOutbox.PENDENTE);
     }
 
 }

--- a/src/main/java/com/restaurante01/api_restaurante/compartilhado/infraestrutura/scheduler/OutboxDespachante.java
+++ b/src/main/java/com/restaurante01/api_restaurante/compartilhado/infraestrutura/scheduler/OutboxDespachante.java
@@ -1,6 +1,7 @@
 package com.restaurante01.api_restaurante.compartilhado.infraestrutura.scheduler;
 
 import com.restaurante01.api_restaurante.compartilhado.aplicacao.OutboxEventoHandler;
+import com.restaurante01.api_restaurante.compartilhado.dominio.entidade.OutboxEvento;
 import com.restaurante01.api_restaurante.compartilhado.dominio.enums.TipoEvento;
 import com.restaurante01.api_restaurante.compartilhado.dominio.repositorio.OutboxRepositorio;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -29,19 +31,27 @@ public class OutboxDespachante {
     @Scheduled(fixedDelay = 60000)
     @Transactional
     public void reprocessarPendentes() {
-        outboxRepositorio.buscarPendentes().forEach(evento -> {
+        List<OutboxEvento> eventosPendentes = outboxRepositorio.buscarPendentes();
+        PriorityQueue<OutboxEvento> filaDeEventosParaProcessar = new PriorityQueue<>();
+
+        for (OutboxEvento evento : eventosPendentes) {
+            filaDeEventosParaProcessar.offer(evento);
+        }
+        while (!filaDeEventosParaProcessar.isEmpty()) {
+            OutboxEvento evento = filaDeEventosParaProcessar.poll();
             OutboxEventoHandler handler = handlers.get(evento.getTipo());
             if (handler == null) {
                 log.warn("Sem handler para tipo {}", evento.getTipo());
-                return;
+                continue;
             }
             try {
                 handler.processar(evento);
                 evento.processar();
-            } catch (Exception e) {
+            } catch (Exception ex) {
                 evento.registrarFalha();
+            } finally {
+                outboxRepositorio.salvar(evento);
             }
-            outboxRepositorio.salvar(evento);
-        });
+        }
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/inicializador/DatabaseSeeder.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/inicializador/DatabaseSeeder.java
@@ -388,6 +388,23 @@ public class DatabaseSeeder implements CommandLineRunner {
         entityManager.persist(av8);
 
         entityManager.flush();
+
+        // -------------------------------------------------------------------------
+        // RETRODATA PEDIDOS ENTREGUES E CANCELADOS (exceto um de cada)
+        // -------------------------------------------------------------------------
+        LocalDateTime doisDiasAtras = LocalDateTime.now().minusDays(2);
+
+        entityManager.createQuery(
+                "UPDATE Pedido p SET p.dataCriacao = :d, p.dataAtualizacao = :d WHERE p.id IN :ids")
+                .setParameter("d", doisDiasAtras)
+                .setParameter("ids", List.of(p1.getId(), p2.getId(), p3.getId(), p4.getId(), p5.getId(), p6.getId(), p21.getId()))
+                .executeUpdate();
+
+        entityManager.createQuery(
+                "UPDATE Pedido p SET p.dataCriacao = :d, p.dataAtualizacao = :d WHERE p.id = :id")
+                .setParameter("d", doisDiasAtras)
+                .setParameter("id", p19.getId())
+                .executeUpdate();
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/security/springsecurity/SecurityConfigurations.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/security/springsecurity/SecurityConfigurations.java
@@ -35,6 +35,7 @@ public class SecurityConfigurations {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/",
             "/index.html",
+            "/dashboard.html",
             "/favicon.ico",
             "/api/auth/cliente-login",
             "/api/auth/operador-login",
@@ -45,7 +46,8 @@ public class SecurityConfigurations {
             "/cardapio-produto/publico/**",
             "/cliente/cadastro",
             "/operador/cadastro", //teste apenas
-            "/h2-console/**"
+            "/h2-console/**",
+            "/ws/**"
     };
 
     // ROTAS PROTEGIDAS — ordem importa: rotas exatas devem vir antes de padrões com variáveis de path

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/api/controlador/operador/PedidoOperadorControlador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/api/controlador/operador/PedidoOperadorControlador.java
@@ -86,8 +86,6 @@ public class PedidoOperadorControlador {
 
         // Notifica o cliente específico e o painel administrativo
         messagingTemplate.convertAndSend("/topico/pedido/" + id, pedidoAtualizado);
-        messagingTemplate.convertAndSend("/topico/admin-pedidos", pedidoAtualizado);
-
         return ResponseEntity.ok(ApiResponse.success("Recurso Atualizado", pedidoAtualizado));
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/api/dto/saida/PedidoCriadoDTO.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/api/dto/saida/PedidoCriadoDTO.java
@@ -3,6 +3,7 @@ package com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.restaurante01.api_restaurante.modulos.pedido.api.dto.entrada.EnderecoDTO;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.enums.StatusPedido;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -15,6 +16,8 @@ public record PedidoCriadoDTO(
         ValoresCalculoPedidoDTO valores,
         StatusPedido statusPedido,
         EnderecoDTO enderecoDeEntrega,
-        String cupomAplicado
+        String cupomAplicado,
+        LocalDateTime dataCriacao,
+        LocalDateTime dataAtualizacao
 ) {
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/casodeuso/AtualizarStatusPedidoCasoDeUso.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/casodeuso/AtualizarStatusPedidoCasoDeUso.java
@@ -8,6 +8,7 @@ import com.restaurante01.api_restaurante.compartilhado.dominio.enums.TipoEvento;
 import com.restaurante01.api_restaurante.modulos.pedido.api.dto.entrada.StatusPedidoDTO;
 import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.PedidoCriadoDTO;
 import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.mapeador.PedidoMapeador;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.schuduler.OrganizaPedidosPorStatusHandler;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.evento.PedidoCanceladoEvento;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.evento.PedidoEntregueEvento;
@@ -15,7 +16,9 @@ import com.restaurante01.api_restaurante.modulos.pedido.dominio.excecao.PedidoNa
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.porta.PedidoOutboxPorta;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.repositorio.PedidoRepositorio;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.valorobjeto.*;
+import lombok.AllArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +26,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
+@AllArgsConstructor
 public class AtualizarStatusPedidoCasoDeUso {
 
     private final PedidoRepositorio pedidoRepository;
@@ -30,14 +34,7 @@ public class AtualizarStatusPedidoCasoDeUso {
     private final ApplicationEventPublisher publicarEvento;
     private final PedidoOutboxPorta pedidoOutboxPorta;
     private final ObjectMapper  objectMapper;
-
-    public AtualizarStatusPedidoCasoDeUso(PedidoRepositorio pedidoRepository, PedidoMapeador pedidoMapeador, ApplicationEventPublisher publicarEvento, PedidoOutboxPorta pedidoOutboxPorta, ObjectMapper objectMapper) {
-        this.pedidoRepository = pedidoRepository;
-        this.pedidoMapeador = pedidoMapeador;
-        this.publicarEvento = publicarEvento;
-        this.pedidoOutboxPorta = pedidoOutboxPorta;
-        this.objectMapper = objectMapper;
-    }
+    private final OrganizaPedidosPorStatusHandler organizaPedidosPorStatusHandler;
 
     @Transactional
     public PedidoCriadoDTO executar(Long id, StatusPedidoDTO novoStatusDto) throws JsonProcessingException {
@@ -45,6 +42,7 @@ public class AtualizarStatusPedidoCasoDeUso {
                 .orElseThrow(() -> new PedidoNaoEncontradoExcecao("Pedido não localizado: " + id));
         pedido.mudarStatus(novoStatusDto.statusPedido());
         Pedido pedidoAtualizado = pedidoRepository.salvar(pedido);
+        organizaPedidosPorStatusHandler.executar();
         switch (pedido.getStatusPedido()) {
             case ENTREGUE -> publicaEventosSeEntregue(pedidoAtualizado);
             case CANCELADO -> publicaEventosSeCancelado(pedidoAtualizado);

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/mapeador/PedidoMapeador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/mapeador/PedidoMapeador.java
@@ -40,7 +40,9 @@ public class PedidoMapeador {
                 mapearValoresPedidoDTO(pedido.getValores()),
                 pedido.getStatusPedido(),
                 mapearEndereco(pedido.getEnderecoPedidoEntrega()),
-                (pedido.getCupom() == null ? "Nenhum cupom aplicado" : pedido.getCupom().codigoCupom())
+                (pedido.getCupom() == null ? "Nenhum cupom aplicado" : pedido.getCupom().codigoCupom()),
+                pedido.getDataCriacao(),
+                pedido.getDataAtualizacao()
         );
     }
     public PedidoDetalhadoDTO mapearPedidoDetalhadoDto (Pedido pedido){

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/schuduler/OrganizaPedidosPorStatusHandler.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/schuduler/OrganizaPedidosPorStatusHandler.java
@@ -1,17 +1,88 @@
 package com.restaurante01.api_restaurante.modulos.pedido.aplicacao.schuduler;
 
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.PedidoCriadoDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.mapeador.PedidoMapeador;
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.repositorio.PedidoRepositorio;
 import lombok.AllArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
 
 @Service
 @AllArgsConstructor
 public class OrganizaPedidosPorStatusHandler {
 
     private final PedidoRepositorio repositorio;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final PedidoMapeador mapeador;
 
-    @Scheduled(fixedDelay = 30000)
-    public void executar
+
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional(readOnly = true)
+    public void executar(){
+        PriorityQueue<Pedido> pedidosPendentes    =   new PriorityQueue<>(Comparator.comparing(Pedido::getDataAtualizacao));
+        PriorityQueue<Pedido> pedidosEmPreparacao =   new PriorityQueue<>(Comparator.comparing(Pedido::getDataAtualizacao));
+        PriorityQueue<Pedido> pedidosEmEntrega    =   new PriorityQueue<>(Comparator.comparing(Pedido::getDataAtualizacao));
+        PriorityQueue<Pedido> pedidosCancelados   =   new PriorityQueue<>(Comparator.comparing(Pedido::getDataAtualizacao));
+        PriorityQueue<Pedido> pedidosEntregues    =   new PriorityQueue<>(Comparator.comparing(Pedido::getDataAtualizacao));
+        List<Pedido> pedidos = repositorio.buscarParaScheduler();
+        for (Pedido pedido : pedidos) {
+            switch (pedido.getStatusPedido()){
+                case PENDENTE          ->  pedidosPendentes.offer(pedido);
+                case EM_PREPARACAO     ->  pedidosEmPreparacao.offer(pedido);
+                case SAIU_PARA_ENTREGA ->  pedidosEmEntrega.offer(pedido);
+                case CANCELADO         ->  pedidosCancelados.offer(pedido);
+                case ENTREGUE          ->  pedidosEntregues.offer(pedido);
+                }
+            }
+        enviaPedidosPendentes(pedidosPendentes);
+        enviaPedidosEmPreparacao(pedidosEmPreparacao);
+        enviaPedidosEmEntrega(pedidosEmEntrega);
+        enviaPedidosCancelados(pedidosCancelados);
+        enviaPedidosEntregues(pedidosEntregues);
+    }
+
+    public void enviaPedidosPendentes(PriorityQueue<Pedido> pedidosPendentes) {
+        while (!pedidosPendentes.isEmpty()){
+            Pedido pedido = pedidosPendentes.poll();
+            PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
+            messagingTemplate.convertAndSend("/topico/pedidos/pendentes", dto);
+        }
+    }
+    public void enviaPedidosEmPreparacao(PriorityQueue<Pedido> pedidosEmPreparacao){
+        while (!pedidosEmPreparacao.isEmpty()){
+            Pedido pedido = pedidosEmPreparacao.poll();
+            PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
+            messagingTemplate.convertAndSend("/topico/pedidos/em-preparacao", dto);
+        }
+    }
+    public void enviaPedidosEmEntrega(PriorityQueue<Pedido> pedidosEmEntrega){
+        while (!pedidosEmEntrega.isEmpty()){
+            Pedido pedido = pedidosEmEntrega.poll();
+            PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
+            messagingTemplate.convertAndSend("/topico/pedidos/em-entrega", dto);
+
+        }
+    }
+    public void enviaPedidosCancelados(PriorityQueue<Pedido> pedidosCancelados){
+        while (!pedidosCancelados.isEmpty()){
+            Pedido pedido = pedidosCancelados.poll();
+            PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
+            messagingTemplate.convertAndSend("/topico/pedidos/cancelados-recente", dto);
+        }
+    }
+    public void enviaPedidosEntregues(PriorityQueue<Pedido> pedidosEntregue){
+        while (!pedidosEntregue.isEmpty()){
+            Pedido pedido = pedidosEntregue.poll();
+            PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
+            messagingTemplate.convertAndSend("/topico/pedidos/entregues-recente", dto);
+        }
+    }
 
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/schuduler/OrganizaPedidosPorStatusHandler.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/schuduler/OrganizaPedidosPorStatusHandler.java
@@ -1,0 +1,17 @@
+package com.restaurante01.api_restaurante.modulos.pedido.aplicacao.schuduler;
+
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.repositorio.PedidoRepositorio;
+import lombok.AllArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class OrganizaPedidosPorStatusHandler {
+
+    private final PedidoRepositorio repositorio;
+
+    @Scheduled(fixedDelay = 30000)
+    public void executar
+
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/schuduler/OrganizaPedidosPorStatusHandler.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/schuduler/OrganizaPedidosPorStatusHandler.java
@@ -48,21 +48,21 @@ public class OrganizaPedidosPorStatusHandler {
         enviaPedidosEntregues(pedidosEntregues);
     }
 
-    public void enviaPedidosPendentes(PriorityQueue<Pedido> pedidosPendentes) {
+    private void enviaPedidosPendentes(PriorityQueue<Pedido> pedidosPendentes) {
         while (!pedidosPendentes.isEmpty()){
             Pedido pedido = pedidosPendentes.poll();
             PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
             messagingTemplate.convertAndSend("/topico/pedidos/pendentes", dto);
         }
     }
-    public void enviaPedidosEmPreparacao(PriorityQueue<Pedido> pedidosEmPreparacao){
+    private void enviaPedidosEmPreparacao(PriorityQueue<Pedido> pedidosEmPreparacao){
         while (!pedidosEmPreparacao.isEmpty()){
             Pedido pedido = pedidosEmPreparacao.poll();
             PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
             messagingTemplate.convertAndSend("/topico/pedidos/em-preparacao", dto);
         }
     }
-    public void enviaPedidosEmEntrega(PriorityQueue<Pedido> pedidosEmEntrega){
+    private void enviaPedidosEmEntrega(PriorityQueue<Pedido> pedidosEmEntrega){
         while (!pedidosEmEntrega.isEmpty()){
             Pedido pedido = pedidosEmEntrega.poll();
             PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
@@ -70,14 +70,14 @@ public class OrganizaPedidosPorStatusHandler {
 
         }
     }
-    public void enviaPedidosCancelados(PriorityQueue<Pedido> pedidosCancelados){
+    private void enviaPedidosCancelados(PriorityQueue<Pedido> pedidosCancelados){
         while (!pedidosCancelados.isEmpty()){
             Pedido pedido = pedidosCancelados.poll();
             PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);
             messagingTemplate.convertAndSend("/topico/pedidos/cancelados-recente", dto);
         }
     }
-    public void enviaPedidosEntregues(PriorityQueue<Pedido> pedidosEntregue){
+    private void enviaPedidosEntregues(PriorityQueue<Pedido> pedidosEntregue){
         while (!pedidosEntregue.isEmpty()){
             Pedido pedido = pedidosEntregue.poll();
             PedidoCriadoDTO dto = mapeador.mapearPedidoCriadoDto(pedido);

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/dominio/repositorio/PedidoRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/dominio/repositorio/PedidoRepositorio.java
@@ -1,11 +1,13 @@
 package com.restaurante01.api_restaurante.modulos.pedido.dominio.repositorio;
 
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.enums.StatusPedido;
 import com.restaurante01.api_restaurante.modulos.usuario.cliente.dominio.entidade.Cliente;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PedidoRepositorio {
@@ -15,5 +17,6 @@ public interface PedidoRepositorio {
     Page<Pedido> buscarPorCliente(Cliente cliente, Pageable pageable);
     Page<Pedido> buscarPorDataCriacaoEntre(LocalDateTime inicio, LocalDateTime fim, Pageable pageable);
     Optional<LocalDateTime> encontrarPedidoComCupomRecorrente(Long clienteId, String codigoCupom);
+    List<Pedido> buscarPorStatus(StatusPedido statusPedido);
 }
 

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/dominio/repositorio/PedidoRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/dominio/repositorio/PedidoRepositorio.java
@@ -18,8 +18,9 @@ public interface PedidoRepositorio {
     Page<Pedido> buscarPorDataCriacaoEntre(LocalDateTime inicio, LocalDateTime fim, Pageable pageable);
     Optional<LocalDateTime> encontrarPedidoComCupomRecorrente(Long clienteId, String codigoCupom);
     List<Pedido> buscarPorStatus(StatusPedido statusPedido);
-    List<Pedido> buscarPorTodosStatusMenos(StatusPedido statusPedido);
+    List<Pedido> buscarPorTodosStatusMenos(List<StatusPedido> statusPedido);
     List<Pedido> buscarCanceladosRecentes12Horas();
-
+    List<Pedido> buscarEntreguesRecentes12Horas();
+    List<Pedido> buscarParaScheduler();
 }
 

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/dominio/repositorio/PedidoRepositorio.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/dominio/repositorio/PedidoRepositorio.java
@@ -18,5 +18,8 @@ public interface PedidoRepositorio {
     Page<Pedido> buscarPorDataCriacaoEntre(LocalDateTime inicio, LocalDateTime fim, Pageable pageable);
     Optional<LocalDateTime> encontrarPedidoComCupomRecorrente(Long clienteId, String codigoCupom);
     List<Pedido> buscarPorStatus(StatusPedido statusPedido);
+    List<Pedido> buscarPorTodosStatusMenos(StatusPedido statusPedido);
+    List<Pedido> buscarCanceladosRecentes12Horas();
+
 }
 

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/adaptador/PedidoJpaAdaptador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/adaptador/PedidoJpaAdaptador.java
@@ -42,21 +42,34 @@ public class PedidoJpaAdaptador implements PedidoRepositorio {
     public Page<Pedido> buscarPorDataCriacaoEntre(LocalDateTime inicio, LocalDateTime fim, Pageable pageable) {
         return jpa.findByDataCriacaoBetween(inicio, fim, pageable);
     }
+
     @Override
-    public Optional<LocalDateTime> encontrarPedidoComCupomRecorrente (Long idCliente, String codigoCupom){
+    public Optional<LocalDateTime> encontrarPedidoComCupomRecorrente(Long idCliente, String codigoCupom) {
         return jpa.buscarDataUltimoUsoDoCupomPeloCliente(idCliente, codigoCupom);
     }
+
     @Override
-    public List<Pedido> buscarPorStatus(StatusPedido statusPedido){
+    public List<Pedido> buscarPorStatus(StatusPedido statusPedido) {
         return jpa.findByStatusPedidoOrderByDataCriacao(statusPedido);
-    };
-    @Override
-    public List<Pedido> buscarPorTodosStatusMenos(StatusPedido statusPedido){
-        return jpa.findByStatusPedidoNot(statusPedido);
     }
     @Override
-    public List<Pedido> buscarCanceladosRecentes12Horas(){
+    public List<Pedido> buscarPorTodosStatusMenos(List<StatusPedido> statusPedido) {
+        return jpa.findByStatusPedidoNotIn(statusPedido);
+    }
+    @Override
+    public List<Pedido> buscarCanceladosRecentes12Horas() {
         return jpa.findByStatusPedidoAndDataAtualizacaoAfter(StatusPedido.CANCELADO, LocalDateTime.now().minusHours(12));
-
+    }
+    @Override
+    public List<Pedido> buscarEntreguesRecentes12Horas() {
+        return jpa.findByStatusPedidoAndDataAtualizacaoAfter(StatusPedido.ENTREGUE, LocalDateTime.now().minusHours(12));
+    }
+    @Override
+    public List<Pedido> buscarParaScheduler() {
+        return jpa.buscarParaScheduler(
+                List.of(StatusPedido.EM_PREPARACAO, StatusPedido.SAIU_PARA_ENTREGA),
+                List.of(StatusPedido.CANCELADO, StatusPedido.ENTREGUE),
+                LocalDateTime.now().minusHours(12)
+        );
     }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/adaptador/PedidoJpaAdaptador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/adaptador/PedidoJpaAdaptador.java
@@ -1,5 +1,6 @@
 package com.restaurante01.api_restaurante.modulos.pedido.infraestrutura.adaptador;
 
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.enums.StatusPedido;
 import com.restaurante01.api_restaurante.modulos.usuario.cliente.dominio.entidade.Cliente;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.repositorio.PedidoRepositorio;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -47,4 +49,8 @@ public class PedidoJpaAdaptador implements PedidoRepositorio {
     public Optional<LocalDateTime> encontrarPedidoComCupomRecorrente (Long idCliente, String codigoCupom){
         return jpa.buscarDataUltimoUsoDoCupomPeloCliente(idCliente, codigoCupom);
     }
+    @Override
+    public List<Pedido> buscarPorStatus(StatusPedido statusPedido){
+        return jpa.findByStatusPedidoOrderByDataCriacao(statusPedido);
+    };
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/adaptador/PedidoJpaAdaptador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/adaptador/PedidoJpaAdaptador.java
@@ -6,12 +6,9 @@ import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.repositorio.PedidoRepositorio;
 import com.restaurante01.api_restaurante.modulos.pedido.infraestrutura.persistencia.PedidoJPA;
 import lombok.AllArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -53,4 +50,13 @@ public class PedidoJpaAdaptador implements PedidoRepositorio {
     public List<Pedido> buscarPorStatus(StatusPedido statusPedido){
         return jpa.findByStatusPedidoOrderByDataCriacao(statusPedido);
     };
+    @Override
+    public List<Pedido> buscarPorTodosStatusMenos(StatusPedido statusPedido){
+        return jpa.findByStatusPedidoNot(statusPedido);
+    }
+    @Override
+    public List<Pedido> buscarCanceladosRecentes12Horas(){
+        return jpa.findByStatusPedidoAndDataAtualizacaoAfter(StatusPedido.CANCELADO, LocalDateTime.now().minusHours(12));
+
+    }
 }

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/adaptador/PedidoJpaAdaptador.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/adaptador/PedidoJpaAdaptador.java
@@ -67,7 +67,7 @@ public class PedidoJpaAdaptador implements PedidoRepositorio {
     @Override
     public List<Pedido> buscarParaScheduler() {
         return jpa.buscarParaScheduler(
-                List.of(StatusPedido.EM_PREPARACAO, StatusPedido.SAIU_PARA_ENTREGA),
+                List.of(StatusPedido.PENDENTE, StatusPedido.EM_PREPARACAO, StatusPedido.SAIU_PARA_ENTREGA),
                 List.of(StatusPedido.CANCELADO, StatusPedido.ENTREGUE),
                 LocalDateTime.now().minusHours(12)
         );

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/persistencia/PedidoJPA.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/persistencia/PedidoJPA.java
@@ -18,7 +18,7 @@ public interface PedidoJPA extends JpaRepository<Pedido, Long> {
     Page<Pedido> findByCliente_ClienteId(Long clienteId, Pageable pageable);
     Page<Pedido> findByDataCriacaoBetween(LocalDateTime inicio, LocalDateTime fim, Pageable pageable);
     List<Pedido> findByStatusPedidoOrderByDataCriacao(StatusPedido statusPedido);
-    List<Pedido> findByStatusPedidoNot(StatusPedido statusPedido);
+    List<Pedido> findByStatusPedidoNotIn(List<StatusPedido> statusPedido);
     List<Pedido> findByStatusPedidoAndDataAtualizacaoAfter(StatusPedido statusPedido, LocalDateTime limite);
 
     @Query(
@@ -33,4 +33,17 @@ public interface PedidoJPA extends JpaRepository<Pedido, Long> {
     Optional<LocalDateTime> buscarDataUltimoUsoDoCupomPeloCliente(
             @Param("clienteId") Long clienteId,
             @Param("codigoCupom") String codigoCupom);
-    }
+
+    @Query("""
+    SELECT p FROM Pedido p
+    WHERE p.statusPedido IN :ativos
+    OR (p.statusPedido IN :recentes 
+        AND p.dataAtualizacao >= :limite)
+""")
+    List<Pedido> buscarParaScheduler(
+            @Param("ativos") List<StatusPedido> ativos,
+            @Param("recentes") List<StatusPedido> recentes,
+            @Param("limite") LocalDateTime limite
+    );
+
+}

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/persistencia/PedidoJPA.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/persistencia/PedidoJPA.java
@@ -1,6 +1,7 @@
 package com.restaurante01.api_restaurante.modulos.pedido.infraestrutura.persistencia;
 
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.enums.StatusPedido;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,6 +18,8 @@ public interface PedidoJPA extends JpaRepository<Pedido, Long> {
     Page<Pedido> findByCliente_ClienteId(Long clienteId, Pageable pageable);
 
     Page<Pedido> findByDataCriacaoBetween(LocalDateTime inicio, LocalDateTime fim, Pageable pageable);
+
+    List<Pedido> findByStatusPedidoOrderByDataCriacao(StatusPedido statusPedido);
 
     @Query(
             """

--- a/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/persistencia/PedidoJPA.java
+++ b/src/main/java/com/restaurante01/api_restaurante/modulos/pedido/infraestrutura/persistencia/PedidoJPA.java
@@ -16,10 +16,10 @@ import java.util.Optional;
 @Repository
 public interface PedidoJPA extends JpaRepository<Pedido, Long> {
     Page<Pedido> findByCliente_ClienteId(Long clienteId, Pageable pageable);
-
     Page<Pedido> findByDataCriacaoBetween(LocalDateTime inicio, LocalDateTime fim, Pageable pageable);
-
     List<Pedido> findByStatusPedidoOrderByDataCriacao(StatusPedido statusPedido);
+    List<Pedido> findByStatusPedidoNot(StatusPedido statusPedido);
+    List<Pedido> findByStatusPedidoAndDataAtualizacaoAfter(StatusPedido statusPedido, LocalDateTime limite);
 
     @Query(
             """

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -496,7 +496,7 @@ function adicionarCard(containerId, countId, dto, schedulerKey = null) {
     <div class="pc-header">
       <div>
         <div class="pc-id">PEDIDO #${dto.id}</div>
-        <div class="pc-data">${fmtData(dto.dataCriacao)}</div>
+        <div class="pc-data">${clearKey ? 'Atualizado em:' : 'Criado em:'} ${fmtData(clearKey ? dto.dataAtualizacao : dto.dataCriacao)}</div>
       </div>
       <span class="card-status st-${status}">${status.replace(/_/g, ' ')}</span>
     </div>

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -1,0 +1,573 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Kanban — Restaurante</title>
+<style>
+  :root {
+    --bg:        #111827;
+    --surface:   #1f2937;
+    --border:    #374151;
+    --text:      #f3f4f6;
+    --muted:     #9ca3af;
+    --blue:      #3b82f6;
+    --green:     #22c55e;
+    --red:       #ef4444;
+    --yellow:    #f59e0b;
+    --purple:    #8b5cf6;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Segoe UI', system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    height: 100vh;
+    overflow: hidden;
+    font-size: 13px;
+  }
+
+  /* ── LOGIN ── */
+  #tela-login {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+  }
+
+  .login-box {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 32px;
+    width: 340px;
+  }
+
+  .login-box h2 { font-size: 18px; font-weight: 700; margin-bottom: 4px; }
+  .login-box h2 span { color: var(--green); }
+  .login-box p { color: var(--muted); font-size: 12px; margin-bottom: 24px; }
+
+  .form-group { margin-bottom: 14px; }
+  label {
+    display: block; font-size: 11px; font-weight: 600; color: var(--muted);
+    margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.03em;
+  }
+  input {
+    width: 100%; background: var(--bg); border: 1px solid var(--border);
+    color: var(--text); padding: 9px 12px; border-radius: 7px;
+    font-size: 13px; font-family: inherit; outline: none; transition: border-color 0.15s;
+  }
+  input:focus { border-color: var(--blue); }
+
+  .btn-login {
+    width: 100%; padding: 10px; background: var(--blue); color: #fff;
+    border: none; border-radius: 7px; font-size: 14px; font-weight: 600;
+    font-family: inherit; cursor: pointer; margin-top: 4px; transition: opacity 0.15s;
+  }
+  .btn-login:hover { opacity: 0.85; }
+  .btn-login:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  #login-erro { color: var(--red); font-size: 12px; text-align: center; margin-top: 12px; display: none; }
+
+  /* ── KANBAN ── */
+  #tela-kanban { display: none; height: 100vh; flex-direction: column; }
+
+  header {
+    background: var(--surface); border-bottom: 1px solid var(--border);
+    padding: 0 20px; display: flex; align-items: center; justify-content: space-between;
+    height: 48px; flex-shrink: 0;
+  }
+  header h1 { font-size: 15px; font-weight: 700; }
+  header h1 span { color: var(--green); }
+
+  .header-right { display: flex; align-items: center; gap: 14px; }
+
+  #ws-badge {
+    padding: 3px 10px; border-radius: 99px; font-size: 11px; font-weight: 600;
+    background: var(--border); color: var(--muted);
+  }
+  #ws-badge.conectado { background: #14532d; color: #4ade80; }
+  #ws-badge.erro      { background: #450a0a; color: #fca5a5; }
+
+  .btn-sair {
+    padding: 5px 12px; background: var(--border); color: var(--muted);
+    border: none; border-radius: 6px; font-size: 12px; font-family: inherit; cursor: pointer;
+  }
+  .btn-sair:hover { color: var(--text); }
+
+  .kanban {
+    display: flex; align-items: stretch; gap: 12px; padding: 16px;
+    height: calc(100vh - 48px); overflow-x: auto; overflow-y: hidden;
+    box-sizing: border-box;
+  }
+
+  .kanban-col {
+    flex: 0 0 500px; display: flex; flex-direction: column;
+    min-height: 0; max-height: 100%;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 10px; overflow: hidden;
+  }
+
+  .kanban-col-header {
+    padding: 12px 14px; font-size: 11px; font-weight: 700;
+    letter-spacing: 0.05em; text-transform: uppercase; border-bottom: 2px solid var(--border);
+    display: flex; align-items: center; justify-content: space-between; flex-shrink: 0;
+  }
+
+  .kanban-col-header .cnt {
+    padding: 2px 8px; border-radius: 99px; font-size: 10px; font-weight: 700;
+    background: var(--border); color: var(--muted);
+  }
+
+  .col-novos      .kanban-col-header { color: var(--blue);   border-color: var(--blue); }
+  .col-preparacao .kanban-col-header { color: var(--yellow);  border-color: var(--yellow); }
+  .col-entrega    .kanban-col-header { color: var(--purple);  border-color: var(--purple); }
+  .col-cancelados .kanban-col-header { color: var(--red);     border-color: var(--red); }
+  .col-entregues  .kanban-col-header { color: var(--green);   border-color: var(--green); }
+
+  .kanban-cards {
+    flex: 1 1 0; min-height: 0; overflow-y: auto; padding: 10px;
+    display: flex; flex-direction: column; gap: 8px;
+  }
+
+  /* ── CARD ── */
+  .pedido-card {
+    background: var(--bg); border: 1px solid var(--border);
+    border-radius: 8px; padding: 0; font-size: 12px;
+    animation: slideIn 0.2s ease; overflow: hidden; flex-shrink: 0;
+  }
+
+  @keyframes slideIn {
+    from { opacity: 0; transform: translateY(-6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .pc-section { padding: 8px 12px; }
+
+  .pc-divider { border: none; border-top: 1px solid var(--border); margin: 0; }
+
+  /* cabeçalho */
+  .pc-header { padding: 8px 12px; display: flex; align-items: flex-start; justify-content: space-between; gap: 6px; }
+  .pc-id     { font-size: 11px; font-weight: 800; color: var(--text); letter-spacing: 0.03em; }
+  .pc-data   { font-size: 10px; color: var(--muted); margin-top: 2px; }
+
+  .card-status {
+    display: inline-block; padding: 2px 7px; border-radius: 4px; flex-shrink: 0;
+    font-size: 10px; font-weight: 700; letter-spacing: 0.03em; white-space: nowrap;
+  }
+
+  .st-PENDENTE          { background: #1e3a5f; color: #60a5fa; }
+  .st-EM_PREPARACAO     { background: #1f3020; color: #4ade80; }
+  .st-SAIU_PARA_ENTREGA { background: #2d1f4e; color: #c4b5fd; }
+  .st-ENTREGUE          { background: #14532d; color: #86efac; }
+  .st-CANCELADO         { background: #450a0a; color: #fca5a5; }
+
+  /* cliente */
+  .pc-nome { font-weight: 600; color: var(--text); }
+  .pc-meta { font-size: 11px; color: var(--muted); margin-top: 3px; line-height: 1.6; }
+
+  /* itens */
+  .pc-label    { font-size: 10px; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 6px; }
+  .pc-item     { margin-bottom: 7px; }
+  .pc-item-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+  .pc-item-nome{ color: var(--text); font-size: 12px; flex: 1; line-height: 1.4; }
+  .pc-item-sub { font-weight: 700; color: var(--text); font-size: 12px; white-space: nowrap; flex-shrink: 0; }
+  .pc-item-bot { font-size: 11px; color: var(--muted); margin-top: 2px; }
+  .pc-item-obs { font-size: 10px; font-style: italic; color: var(--yellow); margin-top: 2px; padding-left: 4px; }
+
+  /* valores */
+  .pc-val-row   { display: flex; justify-content: space-between; font-size: 11px; color: var(--muted); margin-bottom: 2px; }
+  .pc-desconto  { color: var(--red); }
+  .pc-cupom-tag { display: inline-block; padding: 1px 6px; border-radius: 3px; background: #3b1f06; color: var(--yellow); font-size: 10px; font-weight: 700; margin-left: 4px; }
+  .pc-total     { font-size: 13px; font-weight: 700; color: var(--green); margin-top: 4px; }
+
+  /* endereço */
+  .pc-endereco { font-size: 11px; color: var(--muted); line-height: 1.5; }
+
+  /* ações */
+  .pc-acoes { padding: 8px 12px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+  .pc-btn {
+    padding: 5px 13px; border: none; border-radius: 5px; font-size: 11px; font-weight: 600;
+    font-family: inherit; cursor: pointer; transition: opacity 0.15s;
+  }
+  .pc-btn:hover:not(:disabled) { opacity: 0.82; }
+  .pc-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+  .pc-btn-avancar  { background: var(--blue);  color: #fff; }
+  .pc-btn-cancelar { background: #3b0808; color: #fca5a5; border: 1px solid #7f1d1d; }
+  .pc-erro-inline  { font-size: 11px; color: var(--red); width: 100%; margin-top: 2px; display: none; }
+
+  .empty-col { color: var(--muted); font-size: 11px; text-align: center; padding: 20px 0; }
+
+  ::-webkit-scrollbar { width: 5px; height: 5px; }
+  ::-webkit-scrollbar-track { background: var(--bg); }
+  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+</style>
+</head>
+<body>
+
+<!-- ═══════════ LOGIN ═══════════ -->
+<div id="tela-login">
+  <div class="login-box">
+    <h2>🍔 Kanban <span>Operador</span></h2>
+    <p>Painel em tempo real via WebSocket</p>
+    <div class="form-group">
+      <label>CPF</label>
+      <input id="l-cpf" type="text" value="00000000000" maxlength="11">
+    </div>
+    <div class="form-group">
+      <label>Senha</label>
+      <input id="l-senha" type="password" value="123456">
+    </div>
+    <button class="btn-login" id="btn-entrar" onclick="entrar()">Entrar</button>
+    <div id="login-erro"></div>
+  </div>
+</div>
+
+<!-- ═══════════ KANBAN ═══════════ -->
+<div id="tela-kanban">
+  <header>
+    <h1>🍔 <span>Restaurante</span> — Kanban Tempo Real</h1>
+    <div class="header-right">
+      <span id="ws-badge">⚫ desconectado</span>
+      <span id="op-nome" style="font-size:12px; color:var(--muted)"></span>
+      <button class="btn-sair" onclick="sair()">Sair</button>
+    </div>
+  </header>
+
+  <div class="kanban">
+
+    <div class="kanban-col col-novos">
+      <div class="kanban-col-header">
+        <span>Novos Pedidos</span>
+        <span class="cnt" id="cnt-novos">0</span>
+      </div>
+      <div class="kanban-cards" id="cards-novos">
+        <div class="empty-col">Aguardando pedidos...</div>
+      </div>
+    </div>
+
+    <div class="kanban-col col-preparacao">
+      <div class="kanban-col-header">
+        <span>Em Preparação</span>
+        <span class="cnt" id="cnt-preparacao">0</span>
+      </div>
+      <div class="kanban-cards" id="cards-preparacao">
+        <div class="empty-col">Nenhum</div>
+      </div>
+    </div>
+
+    <div class="kanban-col col-entrega">
+      <div class="kanban-col-header">
+        <span>Saiu p/ Entrega</span>
+        <span class="cnt" id="cnt-entrega">0</span>
+      </div>
+      <div class="kanban-cards" id="cards-entrega">
+        <div class="empty-col">Nenhum</div>
+      </div>
+    </div>
+
+    <div class="kanban-col col-cancelados">
+      <div class="kanban-col-header">
+        <span>Cancelados</span>
+        <span class="cnt" id="cnt-cancelados">0</span>
+      </div>
+      <div class="kanban-cards" id="cards-cancelados">
+        <div class="empty-col">Nenhum</div>
+      </div>
+    </div>
+
+    <div class="kanban-col col-entregues">
+      <div class="kanban-col-header">
+        <span>Entregues</span>
+        <span class="cnt" id="cnt-entregues">0</span>
+      </div>
+      <div class="kanban-cards" id="cards-entregues">
+        <div class="empty-col">Nenhum</div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@6/bundles/stomp.umd.min.js"></script>
+<script>
+let token = null;
+let stompClient = null;
+
+const COLUNAS_SCHEDULER = new Set(['cards-preparacao','cards-entrega','cards-cancelados','cards-entregues']);
+const cicloLimpo  = new Set();
+const cicloTimers = {};
+
+// ── LOGIN ──
+async function entrar() {
+  const cpf   = document.getElementById('l-cpf').value.trim();
+  const senha = document.getElementById('l-senha').value;
+  const btn   = document.getElementById('btn-entrar');
+  const erro  = document.getElementById('login-erro');
+
+  btn.disabled = true;
+  btn.textContent = 'Autenticando...';
+  erro.style.display = 'none';
+
+  try {
+    const r = await fetch('/api/auth/operador-login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cpf, senha })
+    });
+    const data = await r.json();
+    if (!r.ok) throw new Error(data?.mensagem || 'Credenciais inválidas');
+
+    const d = data?.dados;
+    token = d?.token || d?.accessToken || d?.jwt
+         || Object.values(d || {}).find(v => typeof v === 'string' && v.startsWith('ey'));
+    if (!token) throw new Error('Token não encontrado na resposta');
+
+    document.getElementById('op-nome').textContent = d?.operadorDTO?.nome || d?.nome || '';
+    document.getElementById('tela-login').style.display = 'none';
+    document.getElementById('tela-kanban').style.display = 'flex';
+    conectarWebSocket();
+  } catch (e) {
+    erro.textContent = e.message;
+    erro.style.display = 'block';
+    btn.disabled = false;
+    btn.textContent = 'Entrar';
+  }
+}
+
+document.getElementById('l-senha').addEventListener('keydown', e => {
+  if (e.key === 'Enter') entrar();
+});
+
+// ── WEBSOCKET ──
+function conectarWebSocket() {
+  setBadge('', '🟡 conectando...');
+
+  stompClient = new StompJs.Client({
+    webSocketFactory: () => new SockJS('/ws'),
+    connectHeaders: { Authorization: 'Bearer ' + token },
+    reconnectDelay: 5000,
+    onConnect: () => {
+      setBadge('conectado', '🟢 conectado');
+      stompClient.subscribe('/topico/admin-pedidos',              msg => adicionarCard('cards-novos',      'cnt-novos',      JSON.parse(msg.body)));
+      stompClient.subscribe('/topico/pedidos/pendentes',          msg => adicionarCard('cards-novos',      'cnt-novos',      JSON.parse(msg.body), 'pendentes-sched'));
+      stompClient.subscribe('/topico/pedidos/em-preparacao',      msg => adicionarCard('cards-preparacao', 'cnt-preparacao', JSON.parse(msg.body)));
+      stompClient.subscribe('/topico/pedidos/em-entrega',         msg => adicionarCard('cards-entrega',    'cnt-entrega',    JSON.parse(msg.body)));
+      stompClient.subscribe('/topico/pedidos/cancelados-recente', msg => adicionarCard('cards-cancelados', 'cnt-cancelados', JSON.parse(msg.body)));
+      stompClient.subscribe('/topico/pedidos/entregues-recente',  msg => adicionarCard('cards-entregues',  'cnt-entregues',  JSON.parse(msg.body)));
+    },
+    onDisconnect:    () => setBadge('',    '⚫ desconectado'),
+    onStompError:    () => setBadge('erro','🔴 erro de conexão'),
+    onWebSocketClose:() => setBadge('erro','🔴 conexão perdida'),
+  });
+
+  stompClient.activate();
+}
+
+function setBadge(cls, texto) {
+  const el = document.getElementById('ws-badge');
+  el.className = cls;
+  el.textContent = texto;
+}
+
+// ── TRANSIÇÕES DE STATUS ──
+const TRANSICOES = {
+  PENDENTE:          [{ status: 'EM_PREPARACAO',     label: 'Iniciar Preparo',  cor: 'avancar'  },
+                      { status: 'CANCELADO',          label: 'Cancelar',         cor: 'cancelar' }],
+  EM_PREPARACAO:     [{ status: 'SAIU_PARA_ENTREGA', label: 'Saiu p/ Entrega',  cor: 'avancar'  },
+                      { status: 'CANCELADO',          label: 'Cancelar',         cor: 'cancelar' }],
+  SAIU_PARA_ENTREGA: [{ status: 'ENTREGUE',          label: 'Marcar Entregue',  cor: 'avancar'  },
+                      { status: 'CANCELADO',          label: 'Cancelar',         cor: 'cancelar' }],
+};
+
+async function mudarStatus(pedidoId, novoStatus, btnEl) {
+  const acoes = btnEl.closest('.pc-acoes');
+  const erroEl = acoes.querySelector('.pc-erro-inline');
+  const btns   = acoes.querySelectorAll('.pc-btn');
+  const label  = btnEl.textContent;
+
+  btns.forEach(b => b.disabled = true);
+  btnEl.textContent = 'Atualizando...';
+  erroEl.style.display = 'none';
+
+  try {
+    const r = await fetch(`/pedido/operador/${pedidoId}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+      body: JSON.stringify({ statusPedido: novoStatus })
+    });
+    if (!r.ok) {
+      const data = await r.json().catch(() => ({}));
+      throw new Error(data?.mensagem || data?.message || `Erro ${r.status}`);
+    }
+    const card = btnEl.closest('.pedido-card');
+    const cardsContainer = card.closest('.kanban-cards');
+    const countId = cardsContainer.id.replace('cards-', 'cnt-');
+    card.remove();
+    const restantes = cardsContainer.querySelectorAll('.pedido-card').length;
+    document.getElementById(countId).textContent = restantes;
+    if (restantes === 0) cardsContainer.innerHTML = '<div class="empty-col">Nenhum</div>';
+  } catch (e) {
+    erroEl.textContent = e.message;
+    erroEl.style.display = 'block';
+    btns.forEach(b => b.disabled = false);
+    btnEl.textContent = label;
+  }
+}
+
+// ── UTILS ──
+function brl(v) {
+  return v != null ? 'R$ ' + Number(v).toLocaleString('pt-BR', { minimumFractionDigits: 2 }) : '—';
+}
+function fmtCpf(c) {
+  if (!c) return '—';
+  return c.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+}
+function fmtData(iso) {
+  if (!iso) return '—';
+  const [datePart, timePart = ''] = iso.split('T');
+  const [year, month, day] = datePart.split('-');
+  const [hour = '00', minute = '00', rawSec = '00'] = timePart.split(':');
+  const second = rawSec.split('.')[0];
+  return `${day}/${month}/${year} às ${hour}:${minute}:${second}`;
+}
+
+// ── CARDS ──
+// schedulerKey: quando informado, trata a mensagem como parte de um lote do scheduler
+// (limpa a coluna na primeira msg do lote; msgs subsequentes em até 2 s apenas acumulam).
+// Sem schedulerKey e sem COLUNAS_SCHEDULER, apenas acumula (comportamento tempo-real).
+function adicionarCard(containerId, countId, dto, schedulerKey = null) {
+  const container = document.getElementById(containerId);
+  const clearKey  = schedulerKey ?? (COLUNAS_SCHEDULER.has(containerId) ? containerId : null);
+
+  if (clearKey) {
+    if (!cicloLimpo.has(clearKey)) {
+      container.innerHTML = '';
+      document.getElementById(countId).textContent = '0';
+      cicloLimpo.add(clearKey);
+    }
+    clearTimeout(cicloTimers[clearKey]);
+    cicloTimers[clearKey] = setTimeout(() => cicloLimpo.delete(clearKey), 2000);
+  } else {
+    const empty = container.querySelector('.empty-col');
+    if (empty) empty.remove();
+  }
+
+  const status    = dto?.statusPedido || '';
+  const v         = dto?.valores || {};
+  const end       = dto?.enderecoDeEntrega;
+  const itens     = Array.isArray(dto?.itens) ? dto.itens : [];
+  const desconto  = Number(v.desconto || 0);
+  const transicoes = TRANSICOES[status] || [];
+
+  // ── itens HTML ──
+  const itensHtml = itens.map(it => {
+    const obs = it.observacao && it.observacao.trim()
+      ? `<div class="pc-item-obs">↳ ${it.observacao}</div>` : '';
+    return `
+      <div class="pc-item">
+        <div class="pc-item-top">
+          <span class="pc-item-nome">${it.nomeProduto || '?'}</span>
+          <span class="pc-item-sub">${brl(it.subTotal)}</span>
+        </div>
+        <div class="pc-item-bot">${it.quantidade} × ${brl(it.precoUnitario)}</div>
+        ${obs}
+      </div>`;
+  }).join('');
+
+  // ── desconto HTML ──
+  const cupom = dto.cupomAplicado && dto.cupomAplicado.trim() ? dto.cupomAplicado.trim() : null;
+  const descontoHtml = desconto > 0 ? `
+    <div class="pc-val-row pc-desconto">
+      <span>Desconto${cupom ? ` <span class="pc-cupom-tag">${cupom}</span>` : ''}</span>
+      <span>-${brl(desconto)}</span>
+    </div>` : '';
+
+  // ── endereço HTML ──
+  const endHtml = end
+    ? `📍 ${end.rua}, nº ${end.numero} · ${end.bairro} · ${end.cidade}/${end.estado}`
+    : '—';
+
+  const card = document.createElement('div');
+  card.className = 'pedido-card';
+  card.innerHTML = `
+    <div class="pc-header">
+      <div>
+        <div class="pc-id">PEDIDO #${dto.id}</div>
+        <div class="pc-data">${fmtData(dto.dataCriacao)}</div>
+      </div>
+      <span class="card-status st-${status}">${status.replace(/_/g, ' ')}</span>
+    </div>
+
+    <div class="pc-divider"></div>
+
+    <div class="pc-section">
+      <div class="pc-nome">${dto.nomeUsuario || 'Cliente'}</div>
+      <div class="pc-meta">
+        CPF: ${fmtCpf(dto.cpfUsuario)}<br>
+        WhatsApp: ${dto.whatsappUsuario || '—'}
+      </div>
+    </div>
+
+    <div class="pc-divider"></div>
+
+    <div class="pc-section">
+      <div class="pc-label">Itens</div>
+      ${itensHtml || '<div style="color:var(--muted);font-size:11px">—</div>'}
+    </div>
+
+    <div class="pc-divider"></div>
+
+    <div class="pc-section">
+      <div class="pc-val-row"><span>Bruto</span><span>${brl(v.bruto)}</span></div>
+      ${descontoHtml}
+      <div class="pc-val-row pc-total"><span>Total</span><span>${brl(v.total)}</span></div>
+    </div>
+
+    <div class="pc-divider"></div>
+
+    <div class="pc-section pc-endereco">${endHtml}</div>
+
+    ${transicoes.length > 0 ? `
+    <div class="pc-divider"></div>
+    <div class="pc-acoes">
+      ${transicoes.map(t =>
+        `<button class="pc-btn pc-btn-${t.cor}" onclick="mudarStatus(${dto.id},'${t.status}',this)">${t.label}</button>`
+      ).join('')}
+      <div class="pc-erro-inline"></div>
+    </div>` : ''}
+  `;
+
+  if (clearKey) {
+    container.append(card);
+  } else {
+    container.prepend(card);
+  }
+  document.getElementById(countId).textContent = container.querySelectorAll('.pedido-card').length;
+}
+
+// ── LOGOUT ──
+function sair() {
+  if (stompClient) stompClient.deactivate();
+  token = null;
+  stompClient = null;
+
+  ['cards-novos','cards-preparacao','cards-entrega','cards-cancelados','cards-entregues'].forEach(id => {
+    document.getElementById(id).innerHTML = '<div class="empty-col">Aguardando...</div>';
+  });
+  ['cnt-novos','cnt-preparacao','cnt-entrega','cnt-cancelados','cnt-entregues'].forEach(id => {
+    document.getElementById(id).textContent = '0';
+  });
+
+  document.getElementById('tela-kanban').style.display = 'none';
+  document.getElementById('tela-login').style.display = 'flex';
+  document.getElementById('btn-entrar').disabled = false;
+  document.getElementById('btn-entrar').textContent = 'Entrar';
+  document.getElementById('op-nome').textContent = '';
+  setBadge('', '⚫ desconectado');
+}
+</script>
+</body>
+</html>

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -449,7 +449,7 @@ function adicionarCard(containerId, countId, dto, schedulerKey = null) {
       cicloLimpo.add(clearKey);
     }
     clearTimeout(cicloTimers[clearKey]);
-    cicloTimers[clearKey] = setTimeout(() => cicloLimpo.delete(clearKey), 2000);
+    cicloTimers[clearKey] = setTimeout(() => cicloLimpo.delete(clearKey), 500);
   } else {
     const empty = container.querySelector('.empty-col');
     if (empty) empty.remove();

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/casodeuso/AtualizarStatusPedidoCasoDeUsoTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/casodeuso/AtualizarStatusPedidoCasoDeUsoTest.java
@@ -7,6 +7,7 @@ import com.restaurante01.api_restaurante.compartilhado.dominio.enums.TipoEvento;
 import com.restaurante01.api_restaurante.modulos.pedido.api.dto.entrada.StatusPedidoDTO;
 import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.PedidoCriadoDTO;
 import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.mapeador.PedidoMapeador;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.schuduler.OrganizaPedidosPorStatusHandler;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.ItemPedidoBuilder;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
 import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.PedidoBuilder;
@@ -42,6 +43,7 @@ class AtualizarStatusPedidoCasoDeUsoTest {
     @Mock private ApplicationEventPublisher publicarEvento;
     @Mock private PedidoOutboxPorta pedidoOutboxPorta;
     @Mock private ObjectMapper objectMapper;
+    @Mock private OrganizaPedidosPorStatusHandler organizaPedidosPorStatusHandler;
 
     @InjectMocks
     private AtualizarStatusPedidoCasoDeUso casoDeUso;
@@ -69,6 +71,7 @@ class AtualizarStatusPedidoCasoDeUsoTest {
 
         casoDeUso.executar(1L, new StatusPedidoDTO(StatusPedido.ENTREGUE));
 
+        verify(organizaPedidosPorStatusHandler).executar();
         verify(pedidoOutboxPorta).guardarEvento(
                 eq(Agregado.PEDIDO), any(), eq(GatilhoEvento.PEDIDO_ENTREGUE), eq(TipoEvento.COMPUTAR_PONTUACAO_FIDELIDADE), any());
         verify(pedidoOutboxPorta).guardarEvento(
@@ -87,6 +90,7 @@ class AtualizarStatusPedidoCasoDeUsoTest {
 
         casoDeUso.executar(1L, new StatusPedidoDTO(StatusPedido.CANCELADO));
 
+        verify(organizaPedidosPorStatusHandler).executar();
         verify(pedidoOutboxPorta).guardarEvento(
                 eq(Agregado.PEDIDO), any(), eq(GatilhoEvento.PEDIDO_CANCELADO), eq(TipoEvento.ESTORNAR_ESTOQUE_ASSOCIACAO), any());
         verify(pedidoOutboxPorta).guardarEvento(
@@ -105,6 +109,7 @@ class AtualizarStatusPedidoCasoDeUsoTest {
 
         casoDeUso.executar(1L, new StatusPedidoDTO(StatusPedido.EM_PREPARACAO));
 
+        verify(organizaPedidosPorStatusHandler).executar();
         verifyNoInteractions(pedidoOutboxPorta);
         verifyNoInteractions(publicarEvento);
     }

--- a/src/test/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/schuduler/OrganizaPedidosPorStatusHandlerTest.java
+++ b/src/test/java/com/restaurante01/api_restaurante/modulos/pedido/aplicacao/schuduler/OrganizaPedidosPorStatusHandlerTest.java
@@ -1,0 +1,203 @@
+package com.restaurante01.api_restaurante.modulos.pedido.aplicacao.schuduler;
+
+import com.restaurante01.api_restaurante.modulos.pedido.api.dto.saida.PedidoCriadoDTO;
+import com.restaurante01.api_restaurante.modulos.pedido.aplicacao.mapeador.PedidoMapeador;
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.Pedido;
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.entidade.PedidoBuilder;
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.enums.StatusPedido;
+import com.restaurante01.api_restaurante.modulos.pedido.dominio.repositorio.PedidoRepositorio;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrganizaPedidosPorStatusHandlerTest {
+
+    @Mock private PedidoRepositorio repositorio;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+    @Mock private PedidoMapeador mapeador;
+
+    @InjectMocks
+    private OrganizaPedidosPorStatusHandler handler;
+
+    private Pedido pedidoPendente;
+    private Pedido pedidoEmPreparacao;
+    private Pedido pedidoEmEntrega;
+    private Pedido pedidoCancelado;
+    private Pedido pedidoEntregue;
+
+    @BeforeEach
+    void setUp() {
+        pedidoPendente = PedidoBuilder.umPedido().build();
+
+        pedidoEmPreparacao = PedidoBuilder.umPedido().build();
+        pedidoEmPreparacao.mudarStatus(StatusPedido.EM_PREPARACAO);
+
+        pedidoEmEntrega = PedidoBuilder.umPedido().build();
+        pedidoEmEntrega.mudarStatus(StatusPedido.EM_PREPARACAO);
+        pedidoEmEntrega.mudarStatus(StatusPedido.SAIU_PARA_ENTREGA);
+
+        pedidoCancelado = PedidoBuilder.umPedido().build();
+        pedidoCancelado.mudarStatus(StatusPedido.CANCELADO);
+
+        pedidoEntregue = PedidoBuilder.umPedido().build();
+        pedidoEntregue.mudarStatus(StatusPedido.EM_PREPARACAO);
+        pedidoEntregue.mudarStatus(StatusPedido.SAIU_PARA_ENTREGA);
+        pedidoEntregue.mudarStatus(StatusPedido.ENTREGUE);
+    }
+
+    @Test
+    @DisplayName("Deve enviar pedido PENDENTE para o tópico /topico/pedidos/pendentes")
+    void deveEnviarPedidoPendenteParaTopicoCorreto() {
+        PedidoCriadoDTO dto = Instancio.create(PedidoCriadoDTO.class);
+        when(repositorio.buscarParaScheduler()).thenReturn(List.of(pedidoPendente));
+        when(mapeador.mapearPedidoCriadoDto(pedidoPendente)).thenReturn(dto);
+
+        handler.executar();
+
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/pendentes", dto);
+        verify(messagingTemplate, times(1)).convertAndSend(anyString(), any(PedidoCriadoDTO.class));
+    }
+
+    @Test
+    @DisplayName("Deve enviar pedido EM_PREPARACAO para o tópico /topico/pedidos/em-preparacao")
+    void deveEnviarPedidoEmPreparacaoParaTopicoCorreto() {
+        PedidoCriadoDTO dto = Instancio.create(PedidoCriadoDTO.class);
+        when(repositorio.buscarParaScheduler()).thenReturn(List.of(pedidoEmPreparacao));
+        when(mapeador.mapearPedidoCriadoDto(pedidoEmPreparacao)).thenReturn(dto);
+
+        handler.executar();
+
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/em-preparacao", dto);
+        verify(messagingTemplate, times(1)).convertAndSend(anyString(), any(PedidoCriadoDTO.class));
+    }
+
+    @Test
+    @DisplayName("Deve enviar pedido SAIU_PARA_ENTREGA para o tópico /topico/pedidos/em-entrega")
+    void deveEnviarPedidoEmEntregaParaTopicoCorreto() {
+        PedidoCriadoDTO dto = Instancio.create(PedidoCriadoDTO.class);
+        when(repositorio.buscarParaScheduler()).thenReturn(List.of(pedidoEmEntrega));
+        when(mapeador.mapearPedidoCriadoDto(pedidoEmEntrega)).thenReturn(dto);
+
+        handler.executar();
+
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/em-entrega", dto);
+        verify(messagingTemplate, times(1)).convertAndSend(anyString(), any(PedidoCriadoDTO.class));
+    }
+
+    @Test
+    @DisplayName("Deve enviar pedido CANCELADO para o tópico /topico/pedidos/cancelados-recente")
+    void deveEnviarPedidoCanceladoParaTopicoCorreto() {
+        PedidoCriadoDTO dto = Instancio.create(PedidoCriadoDTO.class);
+        when(repositorio.buscarParaScheduler()).thenReturn(List.of(pedidoCancelado));
+        when(mapeador.mapearPedidoCriadoDto(pedidoCancelado)).thenReturn(dto);
+
+        handler.executar();
+
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/cancelados-recente", dto);
+        verify(messagingTemplate, times(1)).convertAndSend(anyString(), any(PedidoCriadoDTO.class));
+    }
+
+    @Test
+    @DisplayName("Deve enviar pedido ENTREGUE para o tópico /topico/pedidos/entregues-recente")
+    void deveEnviarPedidoEntregueParaTopicoCorreto() {
+        PedidoCriadoDTO dto = Instancio.create(PedidoCriadoDTO.class);
+        when(repositorio.buscarParaScheduler()).thenReturn(List.of(pedidoEntregue));
+        when(mapeador.mapearPedidoCriadoDto(pedidoEntregue)).thenReturn(dto);
+
+        handler.executar();
+
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/entregues-recente", dto);
+        verify(messagingTemplate, times(1)).convertAndSend(anyString(), any(PedidoCriadoDTO.class));
+    }
+
+    @Test
+    @DisplayName("Não deve enviar mensagens nem acionar o mapeador quando não há pedidos")
+    void naoDeveEnviarMensagensQuandoNaoHaPedidos() {
+        when(repositorio.buscarParaScheduler()).thenReturn(List.of());
+
+        handler.executar();
+
+        verifyNoInteractions(messagingTemplate);
+        verifyNoInteractions(mapeador);
+    }
+
+    @Test
+    @DisplayName("Deve distribuir pedidos de status diferentes para seus tópicos corretos em uma única execução")
+    void deveDistribuirPedidosDeStatusDiferentesParaTopicosCorretos() {
+        PedidoCriadoDTO dtoPendente     = Instancio.create(PedidoCriadoDTO.class);
+        PedidoCriadoDTO dtoEmPreparacao = Instancio.create(PedidoCriadoDTO.class);
+        PedidoCriadoDTO dtoCancelado    = Instancio.create(PedidoCriadoDTO.class);
+        PedidoCriadoDTO dtoEntregue     = Instancio.create(PedidoCriadoDTO.class);
+
+        when(repositorio.buscarParaScheduler())
+                .thenReturn(List.of(pedidoPendente, pedidoEmPreparacao, pedidoCancelado, pedidoEntregue));
+        when(mapeador.mapearPedidoCriadoDto(pedidoPendente)).thenReturn(dtoPendente);
+        when(mapeador.mapearPedidoCriadoDto(pedidoEmPreparacao)).thenReturn(dtoEmPreparacao);
+        when(mapeador.mapearPedidoCriadoDto(pedidoCancelado)).thenReturn(dtoCancelado);
+        when(mapeador.mapearPedidoCriadoDto(pedidoEntregue)).thenReturn(dtoEntregue);
+
+        handler.executar();
+
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/pendentes",          dtoPendente);
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/em-preparacao",      dtoEmPreparacao);
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/cancelados-recente", dtoCancelado);
+        verify(messagingTemplate).convertAndSend("/topico/pedidos/entregues-recente",  dtoEntregue);
+        verify(messagingTemplate, times(4)).convertAndSend(anyString(), any(PedidoCriadoDTO.class));
+    }
+
+    @Test
+    @DisplayName("Deve enviar pedidos do mesmo status do mais antigo para o mais recente por dataAtualizacao")
+    void deveEnviarPedidosOrdenadosPorDataAtualizacaoCrescente() throws Exception {
+        Pedido pedidoAntigo  = PedidoBuilder.umPedido().build();
+        Pedido pedidoRecente = PedidoBuilder.umPedido().build();
+        setarCampoHerdado(pedidoAntigo,  "dataAtualizacao", LocalDateTime.now().minusHours(2));
+        setarCampoHerdado(pedidoRecente, "dataAtualizacao", LocalDateTime.now());
+
+        PedidoCriadoDTO dtoAntigo  = Instancio.create(PedidoCriadoDTO.class);
+        PedidoCriadoDTO dtoRecente = Instancio.create(PedidoCriadoDTO.class);
+        when(repositorio.buscarParaScheduler()).thenReturn(List.of(pedidoRecente, pedidoAntigo));
+        when(mapeador.mapearPedidoCriadoDto(pedidoAntigo)).thenReturn(dtoAntigo);
+        when(mapeador.mapearPedidoCriadoDto(pedidoRecente)).thenReturn(dtoRecente);
+
+        handler.executar();
+
+        InOrder ordem = inOrder(messagingTemplate);
+        ordem.verify(messagingTemplate).convertAndSend("/topico/pedidos/pendentes", dtoAntigo);
+        ordem.verify(messagingTemplate).convertAndSend("/topico/pedidos/pendentes", dtoRecente);
+    }
+
+    private void setarCampoHerdado(Object obj, String nomeCampo, Object valor) {
+        try {
+            Class<?> clazz = obj.getClass();
+            while (clazz != null) {
+                try {
+                    Field field = clazz.getDeclaredField(nomeCampo);
+                    field.setAccessible(true);
+                    field.set(obj, valor);
+                    return;
+                } catch (NoSuchFieldException e) {
+                    clazz = clazz.getSuperclass();
+                }
+            }
+            throw new RuntimeException("Campo não encontrado: " + nomeCampo);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## História relacionada

**RA-63** — Como administrador quero receber pedidos de todos os status, por ordem de criação quando status pendente e por ordem de atualização quando outro status em tempo real.

---

## O que foi implementado

### RA-64 — Infraestrutura de busca por status
- Adicionado `buscarPorStatus(StatusPedido)`, `buscarParaScheduler()`, `buscarCanceladosRecentes12Horas()` e `buscarEntreguesRecentes12Horas()` no `PedidoRepositorio`
- Implementação via `PedidoJPA` com queries JPQL dedicadas

### RA-66 — Scheduler de organização por status
- Criado `OrganizaPedidosPorStatusHandler` com `@Scheduled(fixedDelay = 60_000)`
- Usa `PriorityQueue` por status, ordenando por `dataAtualizacao` (mais antigo primeiro)
- Distribui pedidos para os tópicos WebSocket corretos a cada 60 segundos

### RA-67 — Datas no DTO e no dashboard
- Adicionados `dataCriacao` e `dataAtualizacao` no `PedidoCriadoDTO`
- Dashboard exibe label **"Criado em"** para pedidos vindos do canal `/pendentes` e **"Atualizado em"** para os demais canais

### RA-69 — Remoção do envio redundante ao atualizar status
- Removida chamada desnecessária ao tópico `/topico/admin-pedidos` em `AtualizarStatusPedidoCasoDeUso`
- Dashboard Kanban passa a ser alimentado exclusivamente pelo scheduler

### RA-70 — Disparo do scheduler ao atualizar status
- `AtualizarStatusPedidoCasoDeUso.executar()` aciona `OrganizaPedidosPorStatusHandler.executar()` após salvar o pedido, garantindo atualização imediata do dashboard no evento de mudança de status

### RA-71 — Ordenação garantida no Outbox e cobertura de testes
- `OutboxEvento` implementa `Comparable<OutboxEvento>` ordenando por `criadoEm`, com desempate por `id`
- `OutboxDespachante.reprocessarPendentes()` passa a usar `PriorityQueue` para processar eventos do mais antigo ao mais recente
- `OutboxJPA` corrigido para `findByStatusOrderByCriadoEmAsc`, garantindo consistência entre camada de repositório e fila em memória
- Criados testes unitários para `OrganizaPedidosPorStatusHandler` (8 cenários: roteamento por status, ausência de mensagens, distribuição múltipla e ordenação por `dataAtualizacao`)
- Atualizado `AtualizarStatusPedidoCasoDeUsoTest` com mock do `OrganizaPedidosPorStatusHandler`

---

## Canais WebSocket entregues

| Tópico | Status |
|---|---|
| `/topico/pedidos/pendentes` | PENDENTE |
| `/topico/pedidos/em-preparacao` | EM_PREPARACAO |
| `/topico/pedidos/em-entrega` | SAIU_PARA_ENTREGA |
| `/topico/pedidos/cancelados-recente` | CANCELADO |
| `/topico/pedidos/entregues-recente` | ENTREGUE |

## Decisões técnicas

- **`PriorityQueue` em vez de `sort()`**: garante extração O(log n) mantendo a ordenação sem reordenar a lista inteira a cada ciclo
- **Scheduler aciona no evento de status**: a atualização do dashboard não depende apenas do tick do scheduler — qualquer mudança de status reflete imediatamente via `executar()` síncrono
- **Outbox com `Comparable` + `OrderByCriadoEmAsc`**: dupla garantia de ordenação — o banco já retorna ordenado e a `PriorityQueue` reforça em memória, tornando o comportamento previsível independente do driver

## Testes

- 294 testes — todos passando
- Cobertura adicionada: `OrganizaPedidosPorStatusHandlerTest` (8 testes), `AtualizarStatusPedidoCasoDeUsoTest` (atualizado)