### PR TITLE
RA-63: Fix 403 ao acessar /dashboard em produção

### DIFF
--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/configs/web/WebConfig.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/configs/web/WebConfig.java
@@ -1,0 +1,14 @@
+package com.restaurante01.api_restaurante.infraestrutura.configs.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addViewController("/dashboard").setViewName("forward:/dashboard.html");
+    }
+}

--- a/src/main/java/com/restaurante01/api_restaurante/infraestrutura/security/springsecurity/SecurityConfigurations.java
+++ b/src/main/java/com/restaurante01/api_restaurante/infraestrutura/security/springsecurity/SecurityConfigurations.java
@@ -35,6 +35,7 @@ public class SecurityConfigurations {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/",
             "/index.html",
+            "/dashboard",
             "/dashboard.html",
             "/favicon.ico",
             "/api/auth/cliente-login",


### PR DESCRIPTION
## Problema

Após o deploy no Render, acessar `https://sistema-restaurante-api.onrender.com/dashboard` retornava **HTTP 403**.

Duas causas combinadas:

1. **Spring Security** — a rota `/dashboard` não estava nos `PUBLIC_ENDPOINTS` (apenas `/dashboard.html` estava liberado), fazendo a requisição cair na regra `anyRequest().hasRole("ADMIN3")`
2. **Spring Boot 3.x** — suffix pattern matching está desabilitado por padrão, então `/dashboard` não resolve automaticamente para `dashboard.html`

## Solução

- `SecurityConfigurations`: adicionado `/dashboard` nos `PUBLIC_ENDPOINTS`
- `WebConfig` (novo): implementa `WebMvcConfigurer` e registra forward de `/dashboard` → `/dashboard.html`

## Arquivos alterados

- `infraestrutura/security/springsecurity/SecurityConfigurations.java`
- `infraestrutura/configs/web/WebConfig.java` _(novo)_